### PR TITLE
merge

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,17 @@
+2013-02-10
+  bumped version to 0.8.6
+
+  update requirements.txt to remove distribute reference
+  github commit 3b9214a879e5fbd03036a7d4ae86babc03784846
+
+  Merge pull request #33 from iElectric/profile_image_url_https
+  github commit 67cbb8390701c945a48094795474ca485f092049
+  patch by iElectric on github
+
+  Change User.NewFromJsonDict so that it will pull from either
+  profile_image_url_https or profile_image_url to keep older code
+  working properly if they have stored older json data
+
 2013-02-07
   bumped version to 0.8.5
   lots of changes have been happening on Github and i've been

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 '''The setup and build script for the python-twitter library.'''
 
 __author__ = 'python-twitter@googlegroups.com'
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 
 
 # The base package metadata to be used by both distutils and setuptools

--- a/twitter.py
+++ b/twitter.py
@@ -17,7 +17,7 @@
 '''A library that provides a Python interface to the Twitter API'''
 
 __author__ = 'python-twitter@googlegroups.com'
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 
 
 import calendar
@@ -1356,7 +1356,7 @@ class User(object):
                 followers_count=data.get('followers_count', None),
                 favourites_count=data.get('favourites_count', None),
                 friends_count=data.get('friends_count', None),
-                profile_image_url=data.get('profile_image_url_https', None),
+                profile_image_url=data.get('profile_image_url_https', data.get('profile_image_url', None)),
                 profile_background_tile = data.get('profile_background_tile', None),
                 profile_background_image_url = data.get('profile_background_image_url', None),
                 profile_sidebar_fill_color = data.get('profile_sidebar_fill_color', None),


### PR DESCRIPTION
bumped version to 0.8.6

  update requirements.txt to remove distribute reference
  github commit 3b9214a879e5fbd03036a7d4ae86babc03784846

  Merge pull request #33 from iElectric/profile_image_url_https
  github commit 67cbb8390701c945a48094795474ca485f092049
  patch by iElectric on github

  Change User.NewFromJsonDict so that it will pull from either
  profile_image_url_https or profile_image_url to keep older code
  working properly if they have stored older json data
