### PR TITLE
disable the 140 chars counting before posting a tweet

### DIFF
--- a/twitter.py
+++ b/twitter.py
@@ -2824,9 +2824,9 @@ class Api(object):
     else:
       u_status = unicode(status, self._input_encoding)
 
-    if self._calculate_status_length(u_status, self._shortlink_size) > CHARACTER_LIMIT:
-      raise TwitterError("Text must be less than or equal to %d characters. "
-                         "Consider using PostUpdates." % CHARACTER_LIMIT)
+    #if self._calculate_status_length(u_status, self._shortlink_size) > CHARACTER_LIMIT:
+    #  raise TwitterError("Text must be less than or equal to %d characters. "
+    #                     "Consider using PostUpdates." % CHARACTER_LIMIT)
 
     data = {'status': status}
     if in_reply_to_status_id:


### PR DESCRIPTION
there is a bug where non-English messages are limited to less than 140 characters because unicode characters are counted as more than 1 character.
the simplistic, yet working, solution is to remove the client side restriction for a message to have 140 and send it anyway.
that way longer than 140 characters messages will be rejected by twitter server rather than in the client (which makes sense, the client shouldn't be enforcing server rules at the first place TMHO)
