### PR TITLE
get_access_token.py: sending oauth_callback=oob in order to obtain PIN

### DIFF
--- a/get_access_token.py
+++ b/get_access_token.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 # parse_qsl moved to urlparse module in v2.6
 try:
     from urlparse import parse_qsl
@@ -29,60 +27,55 @@ ACCESS_TOKEN_URL = 'https://api.twitter.com/oauth/access_token'
 AUTHORIZATION_URL = 'https://api.twitter.com/oauth/authorize'
 SIGNIN_URL = 'https://api.twitter.com/oauth/authenticate'
 
-consumer_key = None
-consumer_secret = None
 
+def get_access_token(consumer_key, consumer_secret):
 
-if consumer_key is None or consumer_secret is None:
-    print 'You need to edit this script and provide values for the'
-    print 'consumer_key and also consumer_secret.'
-    print ''
-    print 'The values you need come from Twitter - you need to register'
-    print 'as a developer your "application".    This is needed only until'
-    print 'Twitter finishes the idea they have of a way to allow open-source'
-    print 'based libraries to have a token that can be used to generate a'
-    print 'one-time use key that will allow the library to make the request'
-    print 'on your behalf.'
-    print ''
-    sys.exit(1)
+    signature_method_hmac_sha1 = oauth.SignatureMethod_HMAC_SHA1()
+    oauth_consumer = oauth.Consumer(key=consumer_key, secret=consumer_secret)
+    oauth_client = oauth.Client(oauth_consumer)
 
-signature_method_hmac_sha1 = oauth.SignatureMethod_HMAC_SHA1()
-oauth_consumer = oauth.Consumer(key=consumer_key, secret=consumer_secret)
-oauth_client = oauth.Client(oauth_consumer)
+    print 'Requesting temp token from Twitter'
 
-print 'Requesting temp token from Twitter'
-
-resp, content = oauth_client.request(REQUEST_TOKEN_URL, 'POST', body="oauth_callback=oob")
-
-if resp['status'] != '200':
-    print 'Invalid respond from Twitter requesting temp token: %s' % resp['status']
-else:
-    request_token = dict(parse_qsl(content))
-
-    print ''
-    print 'Please visit this Twitter page and retrieve the pincode to be used'
-    print 'in the next step to obtaining an Authentication Token:'
-    print ''
-    print '%s?oauth_token=%s' % (AUTHORIZATION_URL, request_token['oauth_token'])
-    print ''
-
-    pincode = raw_input('Pincode? ')
-
-    token = oauth.Token(request_token['oauth_token'], request_token['oauth_token_secret'])
-    token.set_verifier(pincode)
-
-    print ''
-    print 'Generating and signing request for an access token'
-    print ''
-
-    oauth_client = oauth.Client(oauth_consumer, token)
-    resp, content = oauth_client.request(ACCESS_TOKEN_URL, method='POST', body='oauth_callback=oob&oauth_verifier=%s' % pincode)
-    access_token = dict(parse_qsl(content))
+    resp, content = oauth_client.request(REQUEST_TOKEN_URL, 'POST', body="oauth_callback=oob")
 
     if resp['status'] != '200':
-        print 'The request for a Token did not succeed: %s' % resp['status']
-        print access_token
+        print 'Invalid respond from Twitter requesting temp token: %s' % resp['status']
     else:
-        print 'Your Twitter Access Token key: %s' % access_token['oauth_token']
-        print '          Access Token secret: %s' % access_token['oauth_token_secret']
+        request_token = dict(parse_qsl(content))
+
         print ''
+        print 'Please visit this Twitter page and retrieve the pincode to be used'
+        print 'in the next step to obtaining an Authentication Token:'
+        print ''
+        print '%s?oauth_token=%s' % (AUTHORIZATION_URL, request_token['oauth_token'])
+        print ''
+
+        pincode = raw_input('Pincode? ')
+
+        token = oauth.Token(request_token['oauth_token'], request_token['oauth_token_secret'])
+        token.set_verifier(pincode)
+
+        print ''
+        print 'Generating and signing request for an access token'
+        print ''
+
+        oauth_client = oauth.Client(oauth_consumer, token)
+        resp, content = oauth_client.request(ACCESS_TOKEN_URL, method='POST', body='oauth_callback=oob&oauth_verifier=%s' % pincode)
+        access_token = dict(parse_qsl(content))
+
+        if resp['status'] != '200':
+            print 'The request for a Token did not succeed: %s' % resp['status']
+            print access_token
+        else:
+            print 'Your Twitter Access Token key: %s' % access_token['oauth_token']
+            print '          Access Token secret: %s' % access_token['oauth_token_secret']
+            print ''
+
+
+def main():
+    consumer_key = raw_input('Enter your consumer key: ')
+    consumer_secret = raw_input("Enter your consumer secret: ")
+    get_access_token(consumer_key, consumer_secret)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Quote from twitter API documentation

> The PIN-based flow is implemented in the same exact way as Implementing Sign in with Twitter and 3-legged authorization, with the only difference being that the value for **oauth_callback must be set to oob** during the POST oauth/request_token call.
> Without that, twitter will always redirect user to callback set in application settings.

_This script is very old, but pretty useful. I'll commit some other improvements later._
_P.S. this is almost the first pull request I send to github._
