### PR TITLE
Introducing 'count' for GetFollowers and GetFriends

### DIFF
--- a/twitter.py
+++ b/twitter.py
@@ -3611,8 +3611,8 @@ class Api(object):
         Should be set to -1 for the initial call and then is used to
         control what result page Twitter returns [Optional(ish)]
       count:
-	The number of users to return per page, up to a maximum of 200.
-	Defaults to 20. [Optional]
+        The number of users to return per page, up to a maximum of 200.
+        Defaults to 20. [Optional]
       skip_status:
         If True the statuses will not be returned in the user items.
         [Optional]
@@ -3794,8 +3794,8 @@ class Api(object):
         Should be set to -1 for the initial call and then is used to
         control what result page Twitter returns [Optional(ish)]
       count:
-	The number of users to return per page, up to a maximum of 200.
-	Defaults to 20. [Optional]
+        The number of users to return per page, up to a maximum of 200.
+        Defaults to 20. [Optional]
       skip_status:
         If True the statuses will not be returned in the user items.
         [Optional]


### PR DESCRIPTION
Without any parameter, Twitter sets the number of returned items to 20. The rate limit is set to 15, so that requesting more than 300 Followers/Friends information will take a long time. With the parameter 'count' a maximum of 200 can be set, which will encounter less rate limits and speed up the process.
