### PR TITLE
Changes to PostMedia

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -923,7 +923,7 @@ class Api(object):
     if possibly_sensitive:
       data['possibly_sensitive'] = 'true'
     if in_reply_to_status_id:
-      data['in_reply_to_status_id'] = in_reply_to_status_id
+      data['in_reply_to_status_id'] = str(in_reply_to_status_id)
     if latitude is not None and longitude is not None:
       data['lat']  = str(latitude)
       data['long'] = str(longitude)


### PR DESCRIPTION
PostMedia's parameters need to be strings for the requests library. I have made it so the user can enter in either a int or string for the "in_reply_to_status_id" without throwing errors by type casting the variable.

This is in response to issue #152
