### PR TITLE
Allow post media to work with urls

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -919,7 +919,11 @@ class Api(object):
       u_status = unicode(status, self._input_encoding)
 
     data = {'status': status}
-    data['media'] = open(str(media), 'rb').read()
+    if media.startswith('http'):
+        data['media'] = urllib2.urlopen(media).read()
+    else:
+        data['media'] = open(str(media), 'rb').read()
+        
     if possibly_sensitive:
       data['possibly_sensitive'] = 'true'
     if in_reply_to_status_id:


### PR DESCRIPTION
Currently only works with local files, not useful for tweeting images stored remotely (e.g s3)
