### PR TITLE
Fix race condition in _InitializeRootDirectory

### DIFF
--- a/twitter/_file_cache.py
+++ b/twitter/_file_cache.py
@@ -75,11 +75,15 @@ class _FileCache(object):
         if not root_directory:
             root_directory = self._GetTmpCachePath()
         root_directory = os.path.abspath(root_directory)
-        if not os.path.exists(root_directory):
+        try:
             os.mkdir(root_directory)
-        if not os.path.isdir(root_directory):
-            raise _FileCacheError('%s exists but is not a directory' %
-                                  root_directory)
+        except OSError, e:
+            if e.errno == errno.EEXIST and os.path.isdir(root_directory):
+                # directory already exists
+                pass
+            else:
+                # exists but is a file, or no permissions, or...
+                raise
         self._root_directory = root_directory
 
     def _GetPath(self, key):


### PR DESCRIPTION
When running e.g. gunicorn, sometimes the worker processes concurrently check for the tmp dir and then both attempt to create it:

```
[2015-02-16 15:01:46 +0000] [14] [ERROR] Exception in worker process:
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/arbiter.py", line 503, in spawn_worker
    worker.init_process()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/workers/base.py", line 116, in init_process
    self.wsgi = self.app.wsgi()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/app/.heroku/python/lib/python2.7/site-packages/gunicorn/util.py", line 355, in import_app
    __import__(module)
  File "/app/app.py", line 1, in <module>
    from tweety import app
  File "/app/tweety/__init__.py", line 7, in <module>
    from tweety import routes
  File "/app/tweety/routes/__init__.py", line 8, in <module>
    api=twitter.Api(consumer_key=configuration['consumer_key'], consumer_secret=configuration['consumer_secret'], access_token_key=configuration['access_token_key'], access_token_secret=configuration['access_token_secret'])
  File "/app/.heroku/python/lib/python2.7/site-packages/twitter/api.py", line 160, in __init__
    self.SetCache(cache)
  File "/app/.heroku/python/lib/python2.7/site-packages/twitter/api.py", line 3286, in SetCache
    self._cache = _FileCache()
  File "/app/.heroku/python/lib/python2.7/site-packages/twitter/_file_cache.py", line 15, in __init__
    self._InitializeRootDirectory(root_directory)
  File "/app/.heroku/python/lib/python2.7/site-packages/twitter/_file_cache.py", line 78, in _InitializeRootDirectory
    os.mkdir(root_directory)
OSError: [Errno 17] File exists: '/tmp/python.cache_nobody'
```

This change prevents exceptions on existing dirs, but lets all other error cases bubble up.