### PR TITLE
Fix missing "errno" import introduced in pull request #214.

### DIFF
--- a/twitter/_file_cache.py
+++ b/twitter/_file_cache.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
-from hashlib import md5
+import errno
 import os
 import re
 import tempfile
+
+from hashlib import md5
 
 
 class _FileCacheError(Exception):


### PR DESCRIPTION
Pull request #214 introduced a reference to "errno", but the module was not imported. In some cases it works, but in others it will fail.

Run
```
python twitter_test.py FileCacheTest
```
to verify. Also cleaned up imports according to PEP8.