### PR TITLE
fix tests that weren't already broken on py3

### DIFF
--- a/twitter/_file_cache.py
+++ b/twitter/_file_cache.py
@@ -19,7 +19,8 @@ class _FileCache(object):
     def Get(self, key):
         path = self._GetPath(key)
         if os.path.exists(path):
-            return open(path).read()
+            with open(path) as f:
+                return f.read()
         else:
             return None
 
@@ -85,7 +86,7 @@ class _FileCache(object):
 
     def _GetPath(self, key):
         try:
-            hashed_key = md5(key).hexdigest()
+            hashed_key = md5(key.encode('utf-8')).hexdigest()
         except TypeError:
             hashed_key = md5.new(key).hexdigest()
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -46,6 +46,13 @@ import io
 from twitter import (__version__, _FileCache, simplejson, DirectMessage, List,
                      Status, Trend, TwitterError, User, UserStatus)
 
+try:
+  # python 3
+  urllib_version = urllib.request.__version__
+except AttributeError:
+  # python 2
+  urllib_version = urllib.__version__
+
 CHARACTER_LIMIT = 140
 
 # A singleton representing a lazily instantiated FileCache.
@@ -3468,7 +3475,7 @@ class Api(object):
 
     def _InitializeUserAgent(self):
         user_agent = 'Python-urllib/%s (python-twitter/%s)' % \
-                     (urllib.__version__, __version__)
+                     (urllib_version, __version__)
         self.SetUserAgent(user_agent)
 
     def _InitializeDefaultParameters(self):

--- a/twitter/direct_message.py
+++ b/twitter/direct_message.py
@@ -1,8 +1,13 @@
-from builtins import object
 #!/usr/bin/env python
 
+from builtins import object
+
 from calendar import timegm
-import rfc822
+
+try:
+    from rfc822 import parsedate
+except ImportError:
+    from email.utils import parsedate
 
 from twitter import simplejson, TwitterError
 
@@ -107,7 +112,7 @@ class DirectMessage(object):
         Returns:
           The time this direct message was posted, in seconds since the epoch.
         """
-        return timegm(rfc822.parsedate(self.created_at))
+        return timegm(parsedate(self.created_at))
 
     created_at_in_seconds = property(GetCreatedAtInSeconds,
                                      doc="The time this direct message was "

--- a/twitter/status.py
+++ b/twitter/status.py
@@ -4,7 +4,12 @@ from __future__ import division
 from builtins import object
 from past.utils import old_div
 from calendar import timegm
-import rfc822
+
+try:
+    from rfc822 import parsedate
+except ImportError:
+    from email.utils import parsedate
+
 import time
 
 from twitter import simplejson, Hashtag, TwitterError, Url
@@ -152,7 +157,7 @@ class Status(object):
         Returns:
           The time this status message was posted, in seconds since the epoch.
         """
-        return timegm(rfc822.parsedate(self.created_at))
+        return timegm(parsedate(self.created_at))
 
     created_at_in_seconds = property(GetCreatedAtInSeconds,
                                      doc="The time this status message was "


### PR DESCRIPTION
Here's some fixes to get the tests passing on py3 with the exception of the api tests, which seem to have been already broken because they try to call SetUrllib to use a mock urllib which has apparently been removed.

Might have a crack at fixing that up too at some point.

Tested on python 2.7, 3.4.