### PR TITLE
Fix for PostMultipleMedia media-ids-failed-error

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1000,6 +1000,8 @@ class Api(object):
 
         if type(media) is not list:
             raise TwitterError("Must by multiple media elements")
+        
+        del media[4:]
 
         url = '%s/media/upload.json' % self.upload_url
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1000,8 +1000,9 @@ class Api(object):
 
         if type(media) is not list:
             raise TwitterError("Must by multiple media elements")
-        
-        del media[4:]
+
+        if media.__len__() > 4:
+            raise TwitterError("Maximum of 4 media elements can be allocated to a tweet")
 
         url = '%s/media/upload.json' % self.upload_url
 


### PR DESCRIPTION
After receiving many of the following errors:
{"errors":[{"code":324,"message":"The validation of media ids failed."}]}

And reading here: https://twittercommunity.com/t/the-validation-of-media-ids-failed-error-code-324/29304

I found that Twitter would give this error if you tried to upload more than 4 images at a time. As an immediate fix I'm truncating the list to the maximum that twitter will accept.