### PR TITLE
Remove references to outdated API functionality: GetUserByEmail

### DIFF
--- a/doc/twitter.html
+++ b/doc/twitter.html
@@ -172,7 +172,6 @@
                                 href="#Api-DestroyFriendship">DestroyFriendship</a>(user)<br>
                         &nbsp;&nbsp;&nbsp;&nbsp;&gt;&gt;&gt;&nbsp;api.<a
                                 href="#Api-CreateFriendship">CreateFriendship</a>(user)<br>
-                        &nbsp;&nbsp;&nbsp;&nbsp;&gt;&gt;&gt;&nbsp;api.<a href="#Api-GetUserByEmail">GetUserByEmail</a>(email)<br>
                         &nbsp;&nbsp;&nbsp;&nbsp;&gt;&gt;&gt;&nbsp;api.<a
                                 href="#Api-VerifyCredentials">VerifyCredentials</a>()<br>&nbsp;</tt></td>
                 </tr>
@@ -741,19 +740,6 @@
                                 &nbsp;<br>
                                 Args:<br>
                                 &nbsp;&nbsp;user:&nbsp;The&nbsp;twitter&nbsp;name&nbsp;or&nbsp;id&nbsp;of&nbsp;the&nbsp;user&nbsp;to&nbsp;retrieve.<br>
-                                &nbsp;<br>
-                                Returns:<br>
-                                &nbsp;&nbsp;A&nbsp;twitter.<a href="#User">User</a>&nbsp;instance&nbsp;representing&nbsp;that&nbsp;user</tt>
-                            </dd>
-                        </dl>
-
-                        <dl>
-                            <dt><a name="Api-GetUserByEmail"><strong>GetUserByEmail</strong></a>(self, email)</dt>
-                            <dd><tt>Returns&nbsp;a&nbsp;single&nbsp;user&nbsp;by&nbsp;email&nbsp;address.<br>
-                                &nbsp;<br>
-                                Args:<br>
-                                &nbsp;&nbsp;email:<br>
-                                &nbsp;&nbsp;&nbsp;&nbsp;The&nbsp;email&nbsp;of&nbsp;the&nbsp;user&nbsp;to&nbsp;retrieve.<br>
                                 &nbsp;<br>
                                 Returns:<br>
                                 &nbsp;&nbsp;A&nbsp;twitter.<a href="#User">User</a>&nbsp;instance&nbsp;representing&nbsp;that&nbsp;user</tt>

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -100,7 +100,6 @@ class Api(object):
         >>> api.DestroyFriendship(user)
         >>> api.CreateFriendship(user)
         >>> api.LookupFriendship(user)
-        >>> api.GetUserByEmail(email)
         >>> api.VerifyCredentials()
     """
 


### PR DESCRIPTION
Fix for Issue https://github.com/bear/python-twitter/issues/240

#### Changes
- Remove references in both docstrings (located in api.py) and the html docs themselves, to a deprecated function (`GetUserByEmail(email)`)
