### PR TITLE
Fixed Non-ASCII printable representation in Trend

### DIFF
--- a/twitter/trend.py
+++ b/twitter/trend.py
@@ -13,7 +13,7 @@ class Trend(object):
         self.url = url
 
     def __repr__(self):
-        return self.name
+        return self.name.encode('utf-8')
 
     def __str__(self):
         return 'Name: %s\nQuery: %s\nTimestamp: %s\nSearch URL: %s\n' % (


### PR DESCRIPTION
Hi,

When ```__repr__``` is called on a Trend object, non-ASCII character leads to a UnicodeEncodeError.

*When did this bug occur?*
I am a German twitter User. The API broke on a Trend with name 'Dinge die Mädchen'. The ä is a non-ASCII character.  The full error code was:
```UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 11: ordinal not in range(128)```

I am not sure, if this may occur in other method calls. Basically, Non-ASCII characters should be supported, since twitter is used world-wide.

Thanks for the great API.

Cheers
Daniel