### PR TITLE
Updates Media object with new methods, adds id param, adds tests

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,100 @@
+import twitter
+import json
+import unittest
+
+
+class MediaTest(unittest.TestCase):
+
+    RAW_JSON = '''{"display_url": "pic.twitter.com/lX5LVZO", "expanded_url": "http://twitter.com/fakekurrik/status/244204973972410368/photo/1", "id": 244204973989187584, "id_str": "244204973989187584", "indices": [44,63], "media_url": "http://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png", "media_url_https": "https://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png", "sizes": {"large": {"h": 175, "resize": "fit", "w": 333}, "medium": {"h": 175, "resize": "fit", "w": 333}, "small": {"h": 175, "resize": "fit", "w": 333}, "thumb": {"h": 150, "resize": "crop", "w": 150}}, "type": "photo", "url": "http://t.co/lX5LVZO"}'''
+    SAMPLE_JSON = '''{"display_url": "pic.twitter.com/lX5LVZO", "expanded_url": "http://twitter.com/fakekurrik/status/244204973972410368/photo/1", "id": 244204973989187584, "media_url": "http://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png", "media_url_https": "https://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png", "type": "photo", "url": "http://t.co/lX5LVZO"}'''
+
+    def _GetSampleMedia(self):
+        return twitter.Media(
+            id=244204973989187584,
+            expanded_url='http://twitter.com/fakekurrik/status/244204973972410368/photo/1',
+            display_url='pic.twitter.com/lX5LVZO',
+            url='http://t.co/lX5LVZO',
+            media_url_https='https://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png',
+            media_url='http://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png',
+            type='photo')
+
+    def testInit(self):
+        '''Test the twitter.Media constructor'''
+        media = twitter.Media(
+            id=244204973989187584,
+            display_url='pic.twitter.com/7a2z7S8tKL',
+            expanded_url='http://twitter.com/NASAJPL/status/672830989895254016/photo/1',
+            url='https://t.co/7a2z7S8tKL',
+            media_url_https='https://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg',
+            media_url='http://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg',
+            type='photo')
+
+    def testProperties(self):
+        '''Test all of the twitter.Media properties'''
+        media = twitter.Media()
+
+        media.id = 244204973989187584
+        media.display_url = 'pic.twitter.com/7a2z7S8tKL'
+        media.expanded_url = 'http://twitter.com/NASAJPL/status/672830989895254016/photo/1'
+        media.url = 'https://t.co/7a2z7S8tKL'
+        media.media_url_https = 'https://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg'
+        media.media_url = 'http://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg'
+        media.type = 'photo'
+
+        self.assertEqual('pic.twitter.com/7a2z7S8tKL', media.display_url)
+        self.assertEqual(
+            'http://twitter.com/NASAJPL/status/672830989895254016/photo/1',
+            media.expanded_url)
+        self.assertEqual('https://t.co/7a2z7S8tKL', media.url)
+        self.assertEqual(
+            'https://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg',
+            media.media_url_https)
+        self.assertEqual(
+            'http://pbs.twimg.com/media/CVZgOC3UEAELUcL.jpg',
+            media.media_url)
+        self.assertEqual('photo', media.type)
+
+    def testAsJsonString(self):
+        '''Test the twitter.User AsJsonString method'''
+        self.assertEqual(MediaTest.SAMPLE_JSON,
+                         self._GetSampleMedia().AsJsonString())
+
+    def testAsDict(self):
+        '''Test the twitter.Media AsDict method'''
+        media = self._GetSampleMedia()
+        data = media.AsDict()
+
+        self.assertEqual(
+            'pic.twitter.com/lX5LVZO',
+            data['display_url'])
+        self.assertEqual(
+            'http://twitter.com/fakekurrik/status/244204973972410368/photo/1',
+            data['expanded_url'])
+        self.assertEqual('http://t.co/lX5LVZO', data['url'])
+        self.assertEqual(
+            'https://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png',
+            data['media_url_https'])
+        self.assertEqual(
+            'http://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png',
+            data['media_url'])
+
+        self.assertEqual('photo', data['type'])
+
+    def testEq(self):
+        '''Test the twitter.Media __eq__ method'''
+        media = twitter.Media()
+        media.id = 244204973989187584
+        media.display_url = 'pic.twitter.com/lX5LVZO'
+        media.expanded_url = 'http://twitter.com/fakekurrik/status/244204973972410368/photo/1'
+        media.url = 'http://t.co/lX5LVZO'
+        media.media_url_https = 'https://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png'
+        media.media_url = 'http://pbs.twimg.com/media/A2OXIUcCUAAXj9k.png'
+        media.type = 'photo'
+
+        self.assertEqual(media, self._GetSampleMedia())
+
+    def testNewFromJsonDict(self):
+        '''Test the twitter.Media NewFromJsonDict method'''
+        data = json.loads(MediaTest.RAW_JSON)
+        media = twitter.Media.NewFromJsonDict(data)
+        self.assertEqual(self._GetSampleMedia(), media)

--- a/twitter/media.py
+++ b/twitter/media.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+import json
 
 
 class Media(object):
+
     """A class representing the Media component of a tweet.
 
     The Media structure exposes the following properties:
@@ -20,6 +22,7 @@ class Media(object):
         returned in a sequence.
         """
         param_defaults = {
+            'id': None,
             'expanded_url': None,
             'display_url': None,
             'url': None,
@@ -29,8 +32,12 @@ class Media(object):
             'variants': None
         }
 
-        for (param, default) in param_defaults.iteritems():
+        for (param, default) in param_defaults.items():
             setattr(self, param, kwargs.get(param, default))
+
+    @property
+    def Id(self):
+        return self.id or None
 
     @property
     def Expanded_url(self):
@@ -59,8 +66,35 @@ class Media(object):
     def __eq__(self, other):
         return other.Media_url == self.Media_url and other.Type == self.Type
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __hash__(self):
         return hash((self.Media_url, self.Type))
+
+    def __str__(self):
+        """A string representation of this twitter.Media instance.
+
+        The return value is the same as the JSON string representation.
+
+        Returns:
+          A string representation of this twitter.Media instance.
+        """
+        return self.AsJsonString()
+
+    def __repr__(self):
+        """
+        A string representation of this twitter.Media instance.
+
+        The return value is the ID of status, username and datetime.
+
+        Returns:
+            Media(ID=244204973989187584, type=photo, display_url='pic.twitter.com/lX5LVZO')
+        """
+        return "Media(Id={id}, type={type}, display_url='{url}')".format(
+            id=self.id,
+            type=self.type,
+            url=self.display_url)
 
     def AsDict(self):
         """A dict representation of this twitter.Media instance.
@@ -71,6 +105,8 @@ class Media(object):
           A dict representing this twitter.Media instance
         """
         data = {}
+        if self.id:
+            data['id'] = self.id
         if self.expanded_url:
             data['expanded_url'] = self.expanded_url
         if self.display_url:
@@ -87,7 +123,6 @@ class Media(object):
             data['variants'] = self.variants
         return data
 
-
     @staticmethod
     def NewFromJsonDict(data):
         """Create a new instance based on a JSON dict.
@@ -101,11 +136,19 @@ class Media(object):
         if 'video_info' in data:
             variants = data['video_info']['variants']
 
-        return Media(expanded_url=data.get('expanded_url', None),
+        return Media(id=data.get('id', None),
+                     expanded_url=data.get('expanded_url', None),
                      display_url=data.get('display_url', None),
                      url=data.get('url', None),
                      media_url_https=data.get('media_url_https', None),
                      media_url=data.get('media_url', None),
                      type=data.get('type', None),
-                     variants=variants
-                     )
+                     variants=variants)
+
+    def AsJsonString(self):
+        """A JSON string representation of this twitter.Media instance.
+
+        Returns:
+          A JSON string representation of this twitter.Media instance
+       """
+        return json.dumps(self.AsDict(), sort_keys=True)


### PR DESCRIPTION
I noticed that, since Python 3 removed the `iteritems()` (see line 32) method for dictionaries, constructing a Media object fails.

I also updated the Media object to have parity with User and Status objects with:

* `AsJsonString()` 
* `__str__`
* `__ne__`

methods, since those are present on other objects; Media objects should probably get an ID as well, since this is included with the response from twitter (and might be helpful with chunked media depending on how that gets implemented). 

This is my second pull request, so let me know if I'm doing something wrong. New tests are included, since it doesn't look like Media gets tested as it currently stands.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/264)
<!-- Reviewable:end -->
