### PR TITLE
Add full_text and page options in GetDirectMessages function

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1949,7 +1949,8 @@ class Api(object):
                           count=None,
                           include_entities=True,
                           skip_status=False,
-                          full_text=False):
+                          full_text=False,
+                          page=None):
         """Returns a list of the direct messages sent to the authenticating user.
     
         The twitter.Api instance must be authenticated.
@@ -1978,6 +1979,11 @@ class Api(object):
           full_text:
             When set to True full message will be included in the returned message
             object if message length is bigger than 140 characters. [Optional]
+          page:
+            If you want more than 200 messages, you can use this and get 20 messages
+            each time. You must recall it and increment the page value until it
+            return nothing. You can't use count option with it. First value is 1 and
+            not 0.
     
         Returns:
           A sequence of twitter.DirectMessage instances
@@ -2002,6 +2008,8 @@ class Api(object):
             parameters['skip_status'] = 1
         if full_text:
             parameters['full_text'] = 'true'
+        if page:
+            parameters['page'] = page
 
         json_data = self._RequestUrl(url, 'GET', data=parameters)
         data = self._ParseAndCheckTwitter(json_data.content)


### PR DESCRIPTION
full_text option:
If we don't do that there is a link to the twitter website to see the discussion

page option:
If we have more than 200 unread messages, you can't reach them with the count option. Page option is the answer for this matter.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/266)
<!-- Reviewable:end -->
