### PR TITLE
initialize Api.__auth fixes #119

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -166,6 +166,7 @@ class Api(object):
         self._debugHTTP = debugHTTP
         self._shortlink_size = 19
         self._timeout = timeout
+        self.__auth = None
 
         self._InitializeRequestHeaders(request_headers)
         self._InitializeUserAgent()


### PR DESCRIPTION
This eliminates `AttributeError: 'Api' object has no attribute '_Api__auth'` errors by initializing `Api.__auth` to None. Now, setting the authentication parameters incorrectly results in the proper error message: `TwitterError: {'message': 'Api instance must first be given user credentials.'}`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/267)
<!-- Reviewable:end -->
