### PR TITLE
Fixed wrong link target of PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ A Python wrapper around the Twitter API.
 By the `Python-Twitter Developers <python-twitter@googlegroups.com>`_
 
 .. image:: https://img.shields.io/pypi/v/python-twitter.svg
-    :target: https://pypi.python.org/pypi/parsedatetime/
+    :target: https://pypi.python.org/pypi/python-twitter/
     :alt: Downloads
 
 .. image:: https://travis-ci.org/bear/python-twitter.svg?branch=master


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/279)
<!-- Reviewable:end -->
