### PR TITLE
Adds ChunkedMedia Uploads (videos/gifs) and Deprecates PostMultipleMedia & PostMedia

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -211,6 +211,13 @@ class Api(object):
 
         self.chunk_size = chunk_size
 
+        if self.chunk_size < 1024 * 16:
+            warnings.warn((
+                "A chunk size lower than 16384 may result in too many "
+                "requests to the Twitter API when uploading videos. You are "
+                "strongly advised to increase it above 16384"
+            ))
+
         if consumer_key is not None and (access_token_key is None or
                                          access_token_secret is None):
             print('Twitter now requires an oAuth Access Token for API calls. '

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -928,6 +928,39 @@ class Api(object):
 
         return Status.NewFromJsonDict(data)
 
+    def UploadMediaSimple(self,
+                          media,
+                          additional_owners=None):
+
+        """ Upload a media file to Twitter in one request. Used for small file
+        uploads that do not require chunked uploads.
+
+        Args:
+            media:
+                File-like object to upload.
+            additional_owners: additional Twitter users that are allowed to use
+                The uploaded media. Should be a list of integers. Maximum
+                number of additional owners is capped at 100 by Twitter.
+
+        Returns:
+            media_id:
+                ID of the uploaded media returned by the Twitter API or 0.
+
+        """
+        url = '%s/media/upload.json' % self.upload_url
+        parameters = {}
+
+        parameters['media'] = media.read()
+        if len(additional_owners) > 100:
+            raise TwitterError({'message': 'Maximum of 100 additional owners may be specified for a Media object'})
+        if additional_owners:
+            parameters['additional_owners'] = additional_owners
+
+        resp = self._RequestUrl(url, 'POST', data=parameters)
+        data = self._ParseAndCheckTwitter(resp.content.decode('utf-8'))
+
+        return data.get('media_id', 0)
+
     def PostMedia(self,
                   status,
                   media,

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1166,9 +1166,9 @@ class Api(object):
             "This endpoint has been deprecated by Twitter. Please use "
             "PostUpdate() instead. Details of Twitter's deprecation can be "
             "found at: "
-            "dev.twitter.com/rest/reference/post/statuses/update_with_media",
+            "dev.twitter.com/rest/reference/post/statuses/update_with_media"),
             DeprecationWarning
-        ))
+        )
 
         url = '%s/statuses/update_with_media.json' % self.base_url
 
@@ -1231,6 +1231,11 @@ class Api(object):
           Returns:
               A twitter.Status instance representing the message posted.
         """
+
+        warnings.warn((
+            "This method is deprecated. Please use PostUpdate instead, "
+            "passing a list of media that you would like to associate "
+            "with the updated.", DeprecationWarning))
         if type(media) is not list:
             raise TwitterError("Must by multiple media elements")
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -57,6 +57,8 @@ from twitter.twitter_utils import (
     is_url,
     parse_media_file)
 
+warnings.simplefilter('always', DeprecationWarning)
+
 CHARACTER_LIMIT = 140
 
 # A singleton representing a lazily instantiated FileCache.
@@ -1242,7 +1244,7 @@ class Api(object):
         warnings.warn((
             "This method is deprecated. Please use PostUpdate instead, "
             "passing a list of media that you would like to associate "
-            "with the updated.", DeprecationWarning))
+            "with the updated."), DeprecationWarning, stacklevel=2)
         if type(media) is not list:
             raise TwitterError("Must by multiple media elements")
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -930,7 +930,7 @@ class Api(object):
         parameters = {'status': u_status}
 
         if media:
-            if len(media) > 1:
+            if type(media) is list and len(media) > 1:
                 media_ids = []
                 for media_file in media:
                     _, _, file_size, media_type = parse_media_file(media_file)
@@ -1075,7 +1075,10 @@ class Api(object):
 
         segment_id = 0
         while True:
-            data = media_fp.read(self.chunk_size)
+            try:
+                data = media_fp.read(self.chunk_size)
+            except ValueError:
+                break
             if not data:
                 break
             body = [
@@ -1100,7 +1103,6 @@ class Api(object):
             ]
             body_data = b'\r\n'.join(body)
             headers['Content-Length'] = str(len(body_data))
-            print(body_data)
 
             resp = self._RequestChunkedUpload(url=url,
                                               headers=headers,
@@ -1113,6 +1115,11 @@ class Api(object):
                 return self._ParseAndCheckTwitter(resp.content.decode('utf-8'))
 
             segment_id += 1
+
+        try:
+            media_fp.close()
+        except:
+            pass
 
         # Finalizing the upload:
         parameters = {

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -959,7 +959,7 @@ class Api(object):
                     media_ids = self.UploadMediaSimple(
                         media,
                         media_additional_owners)
-            parameters['media_ids'] = media_ids
+            parameters['media_ids'] = ','.join([str(mid) for mid in media_ids])
 
         if in_reply_to_status_id:
             parameters['in_reply_to_status_id'] = in_reply_to_status_id
@@ -1004,8 +1004,11 @@ class Api(object):
         url = '%s/media/upload.json' % self.upload_url
         parameters = {}
 
-        parameters['media'] = media.read()
-        if len(additional_owners) > 100:
+        media_fp, filename, file_size, media_type = parse_media_file(media)
+
+        parameters['media'] = media_fp.read()
+
+        if additional_owners and len(additional_owners) > 100:
             raise TwitterError({'message': 'Maximum of 100 additional owners may be specified for a Media object'})
         if additional_owners:
             parameters['additional_owners'] = additional_owners

--- a/twitter/twitter_utils.py
+++ b/twitter/twitter_utils.py
@@ -176,15 +176,16 @@ def parse_media_file(passed_media):
             data_file = urlopen(passed_media)
             file_size = data_file.length
         else:
-            with open(os.path.realpath(passed_media), 'rb') as f:
-                filename = os.path.basename(passed_media)
-                data_file = f
-                data_file.seek(0, 2)
-                file_size = data_file.tell()
+            data_file = open(os.path.realpath(passed_media), 'rb')
+            filename = os.path.basename(passed_media)
+            data_file.seek(0, 2)
+            file_size = data_file.tell()
 
     # Otherwise, if a file object was passed in the first place,
     # create the standard reference to media_file (i.e., rename it to fp).
     else:
+        if passed_media.mode != 'rb':
+            raise TwitterError({'message': 'File mode must be "rb".'})
         filename = passed_media.name
         data_file = passed_media
         data_file.seek(0, 2)


### PR DESCRIPTION
#### New Methods:
###### UploadMediaChunked()
* Adds ability to chunk media uploads for videos and large GIFs.
* Method can be called by itself; there's no requirement to use PostUpdate(). Return value will be the `media_id` of the media that was uploaded.

###### UploadMediaSimple()
* For smaller uploads, such as photos that don't require chunked uploads.
* Method can be called by itself; there's no requirement to use PostUpdate(). Return value will be the `media_id` of the media that was uploaded.

#### Changes:

###### twitter.Api
* Now has an attribute called `chunk_size`. The default is 1MB, which seems sensible at the moment. (My RPI2 is working with 3MB chunks for a video bot and it seems fine, but that's literally the only thing that computer does.) 
* If you try to set `chunk_size` below 16KB, then the API will warn you since a 15MB video divided into 15KB chunks will result in > 1000 roundtrips to Twitter, which is not allowed. You only get 999, but I can imagine use cases in which this is desirable, so the Api just nags you about it -- it's not a hard error or anything.

###### PostUpdate()
* Now takes a `media` parameter in line with Twitter's deprecation of the endpoint for `statuses/update_with_media.json`. See https://dev.twitter.com/rest/reference/post/statuses/update_with_media .
* Multiple media owners can be passed as `media_additional_owners`.
* I don't have an application that's authorized to promote videos, so I can't test this, but you can specify a `media_category` as well.

###### PostMultipleMedia()
* Can now be handled from PostUpdate(). Simplifies use here, since you can either pass a single media object or a list of them. Each is processed/parsed on its own, so you don't have to worry about which endpoint to use.
* Adds a deprecation warning since this can be removed later.

###### PostMedia()
* Since this used the deprecated `statuses/update_with_media.json` endpoint, this can be replaced with PostUpdate().
* Adds deprecation warning to method.

The new structure can be seen below, the only difference is that if multiple media are passed to PostUpdate(), then there's a loop that is not visualized to reduce clutter.

![untitled diagram](https://cloud.githubusercontent.com/assets/4955149/12374697/ba579052-bc71-11e5-9ad3-24d193bfb827.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/281)
<!-- Reviewable:end -->
