### PR TITLE
Unicode + Python = day drinking. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@
 
 '''The setup and build script for the python-twitter library.'''
 
-import os
+import os, io
 
 from setuptools import setup, find_packages
 
 
 def read(*paths):
     """Build a file path from *paths* and return the contents."""
-    with open(os.path.join(*paths), 'r') as f:
+    with io.open(os.path.join(*paths), 'r', encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
That fact aside, there is a Python3 and unicode issue with the setup.py file, specifically, in how it opens and reads AUTHORS.rst:

+ /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
Traceback (most recent call last):
  File "setup.py", line 40, in <module>
    read('AUTHORS.rst') + '\n\n' +
  File "setup.py", line 27, in read
    return f.read()
  File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 412: ordinal not in range(128)

This only fails on Python 3 (I tested with 3.4.3). Since we know the encoding of the files is UTF-8, and we aren't concerned about these open() calls for performance, being explicit with encoding='utf-8' and using io.open is the lazy fix that resolves this issue without breaking Python 2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/286)
<!-- Reviewable:end -->
