### PR TITLE
Fix for issue #232 in GetSearch() geocode

### DIFF
--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -163,6 +163,12 @@ class ApiTest(unittest.TestCase):
         self.assertTrue(status, twitter.Status)
         self.assertTrue(status.geo)
         self.assertEqual(status.geo['type'], 'Point')
+        resp = self.api.GetSearch(
+            term="python",
+            geocode=('37.781157,-122.398720,100mi'))
+        status = resp[0]
+        self.assertTrue(status, twitter.Status)
+        self.assertTrue(status.geo)
 
     @responses.activate
     def testGetUsersSearch(self):

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -313,80 +313,91 @@ class Api(object):
                   locale=None,
                   result_type="mixed",
                   include_entities=None):
-        """Return twitter search results for a given term.
+        """Return twitter search results for a given term. You must specify one
+        of term, geocode, or raw_query.
 
         Args:
-          term:
+          term (str, optional):
             Term to search by. Optional if you include geocode.
-          since_id:
+          raw_query (str, optional):
+            A raw query as a string. This should be everything after the "?" in
+            the URL (i.e., the query parameters). You are responsible for all
+            type checking and ensuring that the query string is properly
+            formatted, as it will only be URL-encoded before be passed directly
+            to Twitter with no other checks performed. For advanced usage only.
+          since_id (int, optional):
             Returns results with an ID greater than (that is, more recent
             than) the specified ID. There are limits to the number of
             Tweets which can be accessed through the API. If the limit of
             Tweets has occurred since the since_id, the since_id will be
-            forced to the oldest ID available. [Optional]
-          max_id:
+            forced to the oldest ID available.
+          max_id (int, optional):
             Returns only statuses with an ID less than (that is, older
-            than) or equal to the specified ID. [Optional]
-          until:
+            than) or equal to the specified ID.
+          until (str, optional):
             Returns tweets generated before the given date. Date should be
-            formatted as YYYY-MM-DD. [Optional]
-          since:
+            formatted as YYYY-MM-DD.
+          since (str, optional):
             Returns tweets generated since the given date. Date should be
-            formatted as YYYY-MM-DD. [Optional]
-          geocode:
-            Geolocation information in the form (latitude, longitude, radius)
-            [Optional]
-          count:
-            Number of results to return.  Default is 15 and maxmimum that twitter
-            returns is 100 irrespective of what you type in. [Optional]
-          lang:
-            Language for results as ISO 639-1 code.  Default is None (all languages)
-            [Optional]
-          locale:
-            Language of the search query. Currently only 'ja' is effective. This is
-            intended for language-specific consumers and the default should work in
-            the majority of cases.
-          result_type:
-            Type of result which should be returned.  Default is "mixed".  Other
-            valid options are "recent" and "popular". [Optional]
-          include_entities:
-            If True, each tweet will include a node called "entities,".
+            formatted as YYYY-MM-DD.
+          geocode (str or list or tuple, optional):
+            Geolocation within which to search for tweets. Can be either a
+            string in the form of "latitude,longitude,radius" where latitude
+            and longitude are floats and radius is a string such as "1mi" or
+            "1km" ("mi" or "km" are the only units allowed). For example:
+              >>> api.GetSearch(geocode="37.781157,-122.398720,1mi").
+            Otherwise, you can pass a list of either floats or strings for
+            lat/long and a string for radius:
+              >>> api.GetSearch(geocode=[37.781157, -122.398720, "1mi"])
+              >>> # or:
+              >>> api.GetSearch(geocode=(37.781157, -122.398720, "1mi"))
+              >>> # or:
+              >>> api.GetSearch(geocode=("37.781157", "-122.398720", "1mi"))
+          count (int, optional):
+            Number of results to return.  Default is 15 and maxmimum that
+            Twitter returns is 100 irrespective of what you type in.
+          lang (str, optional):
+            Language for results as ISO 639-1 code.  Default is None
+            (all languages).
+          locale (str, optional):
+            Language of the search query. Currently only 'ja' is effective.
+            This is intended for language-specific consumers and the default
+            should work in the majority of cases.
+          result_type (str, optional):
+            Type of result which should be returned. Default is "mixed".
+            Valid options are "mixed, "recent", and "popular".
+          include_entities (bool, optional):
+            If True, each tweet will include a node called "entities".
             This node offers a variety of metadata about the tweet in a
             discrete structure, including: user_mentions, urls, and
-            hashtags. [Optional]
+            hashtags.
 
         Returns:
-          A sequence of twitter.Status instances, one for each message containing
-          the term
+          list: A sequence of twitter.Status instances, one for each message
+          containing the term, within the bounds of the geocoded area, or
+          given by the raw_query.
         """
-        # Build request parameters
 
         url = '%s/search/tweets.json' % self.base_url
         parameters = {}
 
         if since_id:
-            try:
-                parameters['since_id'] = int(since_id)
-            except ValueError:
-                raise TwitterError({'message': "since_id must be an integer"})
+            parameters['since_id'] = enf_type('since_id', int, since_id)
 
         if max_id:
-            try:
-                parameters['max_id'] = int(max_id)
-            except ValueError:
-                raise TwitterError({'message': "max_id must be an integer"})
+            parameters['max_id'] = enf_type('max_id', int, max_id)
 
         if until:
-            parameters['until'] = until
+            parameters['until'] = enf_type('until', str, until)
 
         if since:
-            parameters['since'] = since
+            parameters['since'] = enf_type('since', str, since)
 
         if lang:
-            parameters['lang'] = lang
+            parameters['lang'] = enf_type('lang', str, lang)
 
         if locale:
-            parameters['locale'] = locale
+            parameters['locale'] = enf_type('locale', str, locale)
 
         if term is None and geocode is None and raw_query is None:
             return []
@@ -395,15 +406,17 @@ class Api(object):
             parameters['q'] = term
 
         if geocode is not None:
-            parameters['geocode'] = ','.join(map(str, geocode))
+            if isinstance(geocode, list) or isinstance(geocode, tuple):
+                parameters['geocode'] = ','.join([str(geo) for geo in geocode])
+            else:
+                parameters['geocode'] = enf_type('geocode', str, geocode)
 
         if include_entities:
-            parameters['include_entities'] = 1
+            parameters['include_entities'] = enf_type('include_entities',
+                                                      bool,
+                                                      include_entities)
 
-        try:
-            parameters['count'] = int(count)
-        except ValueError:
-            raise TwitterError({'message': "count must be an integer"})
+        parameters['count'] = enf_type('count', int, count)
 
         if result_type in ["mixed", "popular", "recent"]:
             parameters['result_type'] = result_type
@@ -418,8 +431,7 @@ class Api(object):
 
         data = self._ParseAndCheckTwitter(resp.content.decode('utf-8'))
 
-        # Return built list of statuses
-        return [Status.NewFromJsonDict(x) for x in data['statuses']]
+        return [Status.NewFromJsonDict(x) for x in data.get('statuses', '')]
 
     def GetUsersSearch(self,
                        term=None,


### PR DESCRIPTION
Geocode information can now be passed directly as a string: `"37.781157,-122.398720,1mi"` or a list/tuple such as `[37.781157,-122.398720,"1mi"]`.

Inline documentation has been updated to reflect change. All tests passing & should not break old behavior.

Added type checking for the other search parameters and updated inline docs for what parameter types `GetSearch()` method expects.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/296)
<!-- Reviewable:end -->
