### PR TITLE
Update to LookupFriendship

### DIFF
--- a/doc/migration_v30.rst
+++ b/doc/migration_v30.rst
@@ -35,7 +35,6 @@ Changes to Existing Methods
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 * No longer accepts ``cursor`` parameter. If you require granular control over the paging of the twitter.list.List members, please user twitter.api.Api.GetListMembersPaged instead.
 
-
 :py:func:`twitter.api.Api.GetSearch`
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 * Adds ``raw_query`` method. See :ref:`raw_queries` for more information.
@@ -43,6 +42,13 @@ Changes to Existing Methods
 :py:func:`twitter.api.Api.GetUserStream`
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 * Parameter 'stall_warning' is now 'stall_warnings' in line with GetStreamFilter and Twitter's naming convention. This should now actually return stall warnings, whereas it did not have any effect previously.
+
+
+:py:func:`twitter.api.Api.LookupFriendship`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+* Method will now accept a list for either ``user_id`` or ``screen_name``. The list can contain either ints, strings, or :py:mod:`twitter.user.User` objects for either ``user_id`` or ``screen_name``.
+* Return value is a list of :py:mod:`twitter.user.UserStatus` objects.
 
 :py:func:`twitter.api.Api.PostUpdate`
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/testdata/get_friendships_lookup_muting.json
+++ b/testdata/get_friendships_lookup_muting.json
@@ -1,0 +1,1 @@
+[{"name": "dick costolo", "id": 6385432, "screen_name": "dickc", "id_str": "6385432", "connections": ["muting"]}]

--- a/testdata/get_friendships_lookup_muting_blocking.json
+++ b/testdata/get_friendships_lookup_muting_blocking.json
@@ -1,0 +1,1 @@
+[{"name": "dick costolo", "id": 6385432, "screen_name": "dickc", "id_str": "6385432", "connections": ["blocking", "muting"]}]

--- a/testdata/get_friendships_lookup_none.json
+++ b/testdata/get_friendships_lookup_none.json
@@ -1,0 +1,1 @@
+[{"id_str": "12", "name": "Jack", "connections": ["none"], "screen_name": "jack", "id": 12}]

--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -1371,7 +1371,7 @@ class ApiTest(unittest.TestCase):
 
         responses.add(
             responses.GET,
-            'https://api.twitter.com/1.1/friendships/lookup.json?user_id=12,13',
+            'https://api.twitter.com/1.1/friendships/lookup.json?user_id=12,6385432',
             body=resp_data,
             match_querystring=True,
             status=200)
@@ -1383,7 +1383,7 @@ class ApiTest(unittest.TestCase):
             status=200)
         responses.add(
             responses.GET,
-            'https://api.twitter.com/1.1/friendships/lookup.json?screen_name=jack,test',
+            'https://api.twitter.com/1.1/friendships/lookup.json?screen_name=jack,dickc',
             body=resp_data,
             match_querystring=True,
             status=200)
@@ -1397,7 +1397,7 @@ class ApiTest(unittest.TestCase):
         # If any of the following produce an unexpect result, the test will
         # fail on a request to a URL that hasn't been set by responses:
         test_user = twitter.User(id=12, screen_name='jack')
-        test_user2 = twitter.User(id=13, screen_name='test')
+        test_user2 = twitter.User(id=6385432, screen_name='dickc')
 
         resp = self.api.LookupFriendship(screen_name='jack')
         resp = self.api.LookupFriendship(screen_name=['jack'])
@@ -1412,3 +1412,30 @@ class ApiTest(unittest.TestCase):
         self.assertRaises(
             twitter.TwitterError,
             lambda: self.api.LookupFriendship())
+
+    @responses.activate
+    def testLookupFriendshipMute(self):
+        with open('testdata/get_friendships_lookup_muting.json') as f:
+            resp_data = f.read()
+        responses.add(
+            responses.GET,
+            'https://api.twitter.com/1.1/friendships/lookup.json?screen_name=dickc',
+            body=resp_data,
+            match_querystring=True,
+            status=200)
+        resp = self.api.LookupFriendship(screen_name='dickc')
+        self.assertEqual(resp[0].muting, True)
+
+    @responses.activate
+    def testLookupFriendshipBlockMute(self):
+        with open('testdata/get_friendships_lookup_muting_blocking.json') as f:
+            resp_data = f.read()
+        responses.add(
+            responses.GET,
+            'https://api.twitter.com/1.1/friendships/lookup.json?screen_name=dickc',
+            body=resp_data,
+            match_querystring=True,
+            status=200)
+        resp = self.api.LookupFriendship(screen_name='dickc')
+        self.assertEqual(resp[0].muting, True)
+        self.assertEqual(resp[0].blocking, True)

--- a/twitter/user.py
+++ b/twitter/user.py
@@ -14,6 +14,10 @@ class UserStatus(object):
       userstatus.screen_name
       userstatus.following
       userstatus.followed_by
+      userstatus.following_received
+      userstatus.following_requested
+      userstatus.blocking
+      userstatus.muting
     """
 
     def __init__(self, **kwargs):
@@ -34,7 +38,11 @@ class UserStatus(object):
             'id_str': None,
             'screen_name': None,
             'following': None,
-            'followed_by': None}
+            'followed_by': None,
+            'following_received': None,
+            'following_requested': None,
+            'blocking': None,
+            'muting': None}
 
         for (param, default) in param_defaults.items():
             setattr(self, param, kwargs.get(param, default))
@@ -105,6 +113,14 @@ class UserStatus(object):
             data['following'] = self.following
         if self.followed_by:
             data['followed_by'] = self.followed_by
+        if self.following_received:
+            data['following_received'] = self.following_received
+        if self.following_requested:
+            data['following_requested'] = self.following_requested
+        if self.blocking:
+            data['blocking'] = self.blocking
+        if self.muting:
+            data['muting'] = self.muting
         return data
 
     @staticmethod
@@ -116,20 +132,37 @@ class UserStatus(object):
         Returns:
           A twitter.UserStatus instance
         """
-        following = None
-        followed_by = None
+        following = False
+        followed_by = False
+        following_received = False
+        following_requested = False
+        blocking = False
+        muting = False
+
         if 'connections' in data:
             if 'following' in data['connections']:
                 following = True
             if 'followed_by' in data['connections']:
                 followed_by = True
+            if 'following_received' in data['connections']:
+                following_received = True
+            if 'following_requested' in data['connections']:
+                following_requested = True
+            if 'blocking' in data['connections']:
+                blocking = True
+            if 'muting' in data['connections']:
+                muting = True
 
         return UserStatus(name=data.get('name', None),
                           id=data.get('id', None),
                           id_str=data.get('id_str', None),
                           screen_name=data.get('screen_name', None),
                           following=following,
-                          followed_by=followed_by)
+                          followed_by=followed_by,
+                          following_received=following_received,
+                          following_requested=following_requested,
+                          blocking=blocking,
+                          muting=muting)
 
 
 class User(object):

--- a/twitter/user.py
+++ b/twitter/user.py
@@ -70,7 +70,11 @@ class UserStatus(object):
                    self.id_str == other.id_str and \
                    self.screen_name == other.screen_name and \
                    self.following == other.following and \
-                   self.followed_by == other.followed_by
+                   self.followed_by == other.followed_by and \
+                   self.following_received == other.following_received and \
+                   self.following_requested == other.following_requested and\
+                   self.muting == other.muting and \
+                   self.blocking == other.blocking
         except AttributeError:
             return False
 


### PR DESCRIPTION
Per discussion on #290 , LookupFriendship can take either ints/strings/Users or lists of those for ``user_id`` or ``screen_name``. Add tests and data for method. 

In working on this, I noticed that Twitter returns some additional information on querying that endpoint. In addition to ``following`` and ``followed_by`` there is now:

* ``following_received`` (your account is private, target user has requested to follow you),
* ``following_requested`` (target user is private, you've requested to follow them), 
* ``muting`` and ``blocking`` (target user is muted or blocked by authenticated user).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/297)
<!-- Reviewable:end -->
