### PR TITLE
fixes content.decode errors for streaming endpoints

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -3969,7 +3969,7 @@ class Api(object):
         resp = self._RequestStream(url, 'GET')
         for line in resp.iter_lines():
             if line:
-                data = self._ParseAndCheckTwitter(line)
+                data = self._ParseAndCheckTwitter(line.decode('utf-8'))
                 yield data
 
     def GetStreamFilter(self,
@@ -4014,7 +4014,7 @@ class Api(object):
         resp = self._RequestStream(url, 'POST', data=data)
         for line in resp.iter_lines():
             if line:
-                data = self._ParseAndCheckTwitter(line)
+                data = self._ParseAndCheckTwitter(line.decode('utf-8'))
                 yield data
 
     def GetUserStream(self,
@@ -4070,7 +4070,7 @@ class Api(object):
         resp = self._RequestStream(url, 'POST', data=data)
         for line in resp.iter_lines():
             if line:
-                data = self._ParseAndCheckTwitter(line)
+                data = self._ParseAndCheckTwitter(line.decode('utf-8'))
                 yield data
 
     def VerifyCredentials(self):


### PR DESCRIPTION
The streaming endpoints didn't properly decode the bytes-string from the response when passing to ``_ParseAndCheckTwitter()``, thereby raising a ``TypeError`` when calling ``json.loads()`` on the response from Twitter.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/300)
<!-- Reviewable:end -->
