### PR TITLE
Fix documentation for order of bbox coordinates

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -3981,7 +3981,7 @@ class Api(object):
           track:
             A list of expressions to track. [Optional]
           locations:
-            A list of Latitude,Longitude pairs (as strings) specifying
+            A list of Longitude,Latitude pairs (as strings) specifying
             bounding boxes for the tweets' origin. [Optional]
           delimited:
             Specifies a message length. [Optional]


### PR DESCRIPTION
When passing coordinates to `api.GetStreamFilter` the locations
parameter should specify coordinates as Longitude,Latitude pairs
instead of Latitude,Longitude

#### Sample code
https://gist.github.com/meyersj/234a59604fde81c0d036

#### References
https://dev.twitter.com/streaming/reference/post/statuses/filter
https://dev.twitter.com/streaming/overview/request-parameters#locations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/313)
<!-- Reviewable:end -->
