### PR TITLE
Fix for Issue 320 re Rate Limit

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,15 +1,15 @@
 # encoding: utf-8
 
+import re
 import sys
 import unittest
-
-import twitter
-
 import warnings
 
-warnings.filterwarnings('ignore', category=DeprecationWarning)
-
+import twitter
 import responses
+
+warnings.filterwarnings('ignore', category=DeprecationWarning)
+DEF_URL_RE = re.compile(r'https?://.*\.twitter.com/1\.1/.*')
 
 
 class ErrNull(object):
@@ -60,6 +60,13 @@ class RateLimitTests(unittest.TestCase):
         self.assertTrue(self.api.rate_limit)
         self.assertTrue(self.api.sleep_on_rate_limit)
 
+        responses.add(responses.GET, url=DEF_URL_RE, body=b'{}', status=200)
+        try:
+            self.api.GetStatus(status_id=1234)
+            self.api.GetUser(screen_name='test')
+        except Exception as e:
+            self.fail(e)
+
     @responses.activate
     def testCheckRateLimit(self):
         with open('testdata/ratelimit.json') as f:
@@ -104,6 +111,7 @@ class RateLimitMethodsTests(unittest.TestCase):
             status=200)
         self.api.InitializeRateLimit()
         self.assertTrue(self.api.rate_limit)
+
 
     def tearDown(self):
         sys.stderr = self._stderr

--- a/twitter/ratelimit.py
+++ b/twitter/ratelimit.py
@@ -17,8 +17,8 @@ GEO_ID_PLACE_ID = ResourceEndpoint(re.compile(r'/geo/id/\d+'), "/geo/id/:place_i
 SAVED_SEARCHES_DESTROY_ID = ResourceEndpoint(re.compile(r'/saved_searches/destroy/\d+'), "/saved_searches/destroy/:id")
 SAVED_SEARCHES_SHOW_ID = ResourceEndpoint(re.compile(r'/saved_searches/show/\d+'), "/saved_searches/show/:id")
 STATUSES_RETWEETS_ID = ResourceEndpoint(re.compile(r'/statuses/retweets/\d+'), "/statuses/retweets/:id")
-STATUSES_SHOW_ID = ResourceEndpoint(re.compile(r'/statuses/show/\d+'), "/statuses/show/:id")
-USERS_SHOW_ID = ResourceEndpoint(re.compile(r'/users/show/\d+'), "/users/show/:id")
+STATUSES_SHOW_ID = ResourceEndpoint(re.compile(r'/statuses/show'), "/statuses/show/:id")
+USERS_SHOW_ID = ResourceEndpoint(re.compile(r'/users/show'), "/users/show/:id")
 USERS_SUGGESTIONS_SLUG = ResourceEndpoint(re.compile(r'/users/suggestions/\w+$'), "/users/suggestions/:slug")
 USERS_SUGGESTIONS_SLUG_MEMBERS = ResourceEndpoint(re.compile(r'/users/suggestions/.+/members'), "/users/suggestions/:slug/members")
 
@@ -144,7 +144,6 @@ class RateLimit(object):
             reset (int):
                 Epoch time at which the rate limit window will reset.
         """
-
         endpoint = self.url_to_resource(url)
         resource_family = endpoint.split('/')[1]
         self.__dict__['resources'].update(
@@ -174,6 +173,11 @@ class RateLimit(object):
             family_rates = self.resources.get(resource_family).get(endpoint)
         except AttributeError:
             return EndpointRateLimit(limit=15, remaining=15, reset=0)
+
+        if not family_rates:
+            self.set_unknown_limit(url, limit=15, remaining=15, reset=0)
+            return EndpointRateLimit(limit=15, remaining=15, reset=0)
+
         return EndpointRateLimit(family_rates['limit'],
                                  family_rates['remaining'],
                                  family_rates['reset'])


### PR DESCRIPTION
Regex was wrong such that `GetStatus` and `GetUser` would both try to get an endpoint that didn't exist. The previous error catching failed, because an `AttributeError` was never raised when trying to get a rate limit for an endpoint that didn't exist. So `GetStatus` was looking for rate limit information re `/statuses/show/123`, but the URL that method calls is just `/statuses/show.json` and the status_id is a query parameter. Same basic idea for `/users/show/456` v `/users/show.json`

This fixes that and amends the behavior to return a default rate limit object in the case that an endpoint is not found the first time around and then sets it the next time. This might cause some issues if Twitter consistently doesn't update their `/application/rate_limit_status.json` endpoint, but I think we should cross that bridge when we come to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/321)
<!-- Reviewable:end -->
