### PR TITLE
Fix Badge URLs for CircleCI and ReadtheDocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,12 @@ By the `Python-Twitter Developers <python-twitter@googlegroups.com>`_
     :target: https://pypi.python.org/pypi/python-twitter/
     :alt: Downloads
 
-.. image:: https://readthedocs.io/projects/python-twitter/badge/?version=latest
-    :target: http://python-twitter.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/python-twitter/badge/?version=latest
+    :target: http://python-twitter.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://circleci.com/gh/bear/python-twitter/master.svg?style=shield&circle-token=42abb9ffa9e9db463b565f2d47eb0966039bce2d
-    :target: https://circleci.org/gh/bear/python-twitter
+.. image:: https://circleci.com/gh/bear/python-twitter.svg?style=svg
+    :target: https://circleci.com/gh/bear/python-twitter
     :alt: Circle CI
 
 .. image:: http://codecov.io/github/bear/python-twitter/coverage.svg?branch=master


### PR DESCRIPTION
Badge URLs were broken. Looks like the badges for RTDs are staying on the .org domain? They may also just not be redirecting yet, since the change just went live.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/325)
<!-- Reviewable:end -->
