### PR TITLE
Removes shortner param from API per #298

### DIFF
--- a/doc/migration_v30.rst
+++ b/doc/migration_v30.rst
@@ -4,6 +4,11 @@ Migration from v2 to v3
 Changes to Existing Methods
 ===========================
 
+:py:func:`twitter.api.Api()`
+++++++++++++++++++++++++++++
+* ``shortner`` parameter has been removed. Please see `Issue
+  #298 <https://github.com/bear/python-twitter/issues/298>`_.
+
 :py:func:`twitter.api.Api.CreateFavorite`
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 * kwarg param has been changed to ``status_id`` from ``id`` to be consistent

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -132,7 +132,6 @@ class Api(object):
                  input_encoding=None,
                  request_headers=None,
                  cache=DEFAULT_CACHE,
-                 shortner=None,
                  base_url=None,
                  stream_url=None,
                  upload_url=None,
@@ -161,9 +160,6 @@ class Api(object):
           cache:
             The cache instance to use. Defaults to DEFAULT_CACHE.
             Use None to disable caching. [Optional]
-          shortner:
-            The shortner instance to use.  Defaults to None.
-            See shorten_url.py for an example shortner. [Optional]
           base_url:
             The base URL to use to contact the Twitter API.
             Defaults to https://api.twitter.com. [Optional]
@@ -1561,7 +1557,6 @@ class Api(object):
                     parameters['count'] = int(cursor)
                 except ValueError:
                     raise TwitterError({'message': "cursor must be an integer"})
-                    break
             resp = self._RequestUrl(url, 'GET', data=parameters)
             data = self._ParseAndCheckTwitter(resp.content.decode('utf-8'))
             result += [x for x in data['ids']]


### PR DESCRIPTION
From discussion on #298, we're removing the `shortner` param from the API. This change removes it and documents the change on the migration guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/333)
<!-- Reviewable:end -->
