### PR TITLE
Missing field "following" added to User model

### DIFF
--- a/twitter/models.py
+++ b/twitter/models.py
@@ -310,6 +310,7 @@ class User(TwitterModel):
             'description': None,
             'favourites_count': None,
             'followers_count': None,
+            'following': None,
             'friends_count': None,
             'geo_enabled': None,
             'id': None,


### PR DESCRIPTION
Twitter API has field "following" in User's model. It shows if your account is following that user.
https://dev.twitter.com/rest/reference/get/users/show

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/351)
<!-- Reviewable:end -->
