### PR TITLE
Fix for Issue 355

### DIFF
--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -1709,3 +1709,25 @@ class ApiTest(unittest.TestCase):
         resp = self.api._UploadMediaChunkedFinalize(media_id=737956420046356480)
         self.assertEqual(len(responses.calls), 1)
         self.assertTrue(resp)
+
+    @responses.activate
+    def testGetUserSuggestionCategories(self):
+        with open('testdata/get_user_suggestion_categories.json') as f:
+            resp_data = f.read()
+        responses.add(
+            responses.GET,
+            'https://api.twitter.com/1.1/users/suggestions.json',
+            body=resp_data,
+            match_querystring=True,
+            status=200)
+        resp = self.api.GetUserSuggestionCategories()
+        self.assertTrue(type(resp[0]) is twitter.Category)
+
+    @responses.activate
+    def testGetUserSuggestion(self):
+        with open('testdata/get_user_suggestion.json') as f:
+            resp_data = f.read()
+        responses.add(responses.GET, DEFAULT_URL, body=resp_data, status=200)
+        category = twitter.Category(name='Funny', slug='funny', size=20)
+        resp = self.api.GetUserSuggestion(category=category)
+        self.assertTrue(type(resp[0]) is twitter.User)

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -540,7 +540,7 @@ class Api(object):
         Returns:
             A list of users in that category
         """
-        url = '%s/users/suggestions/%s.json' % (self.base_url, category.Slug)
+        url = '%s/users/suggestions/%s.json' % (self.base_url, category.slug)
 
         resp = self._RequestUrl(url, verb='GET')
         data = self._ParseAndCheckTwitter(resp.content.decode('utf-8'))


### PR DESCRIPTION
Fixes issue #355: `category.Slug` attribute should be `category.slug` in `Api.GetUserSuggestion()`. Adds tests for `GetUserSuggestion()` & `GetUserSuggestionCategories()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/356)
<!-- Reviewable:end -->
