### PR TITLE
Bugfix/negative sleep

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4823,7 +4823,7 @@ class Api(object):
 
             if limit.remaining == 0:
                 try:
-                    time.sleep(min(int(limit.reset - time.time()), 0))
+                    time.sleep(max(int(limit.reset - time.time()), 0))
                 except ValueError:
                     pass
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4823,7 +4823,7 @@ class Api(object):
 
             if limit.remaining == 0:
                 try:
-                    time.sleep(int(limit.reset - time.time()))
+                    time.sleep(min(int(limit.reset - time.time()), 0))
                 except ValueError:
                     pass
 


### PR DESCRIPTION
Prevents kick-out of time.sleep() IOErrors when the rate-limit sleep limit time is negative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/361)
<!-- Reviewable:end -->
