### PR TITLE
fix issue 358

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -186,7 +186,7 @@ class Api(object):
         self._InitializeUserAgent()
         self._InitializeDefaultParameters()
 
-        self.rate_limit = None
+        self.rate_limit = RateLimit()
         self.sleep_on_rate_limit = sleep_on_rate_limit
 
         if base_url is None:
@@ -4673,7 +4673,7 @@ class Api(object):
             namedtuple: EndpointRateLimit namedtuple.
 
         """
-        if not self.rate_limit:
+        if not self.rate_limit.__dict__.get('resources', None):
             self.InitializeRateLimit()
 
         if url:
@@ -4853,7 +4853,7 @@ class Api(object):
         else:
             resp = 0  # if not a POST or GET request
 
-        if url and self.sleep_on_rate_limit and self.rate_limit:
+        if url and self.rate_limit:
             limit = resp.headers.get('x-rate-limit-limit', 0)
             remaining = resp.headers.get('x-rate-limit-remaining', 0)
             reset = resp.headers.get('x-rate-limit-reset', 0)

--- a/twitter/ratelimit.py
+++ b/twitter/ratelimit.py
@@ -146,6 +146,12 @@ class RateLimit(object):
         """
         endpoint = self.url_to_resource(url)
         resource_family = endpoint.split('/')[1]
+
+        # This is a conversative check against a situation in which a user has
+        # set api.sleep_on_rate_limit to True, but hasn't made a call
+        if not self.__dict__.get('resources', None):
+            self.__dict__['resources'] = {}
+
         self.__dict__['resources'].update(
             {resource_family: {
                 endpoint: {


### PR DESCRIPTION
Adds ability to set rate limit endpoints even if `api.sleep_on_rate_limit` is False

Basically, if you instantiate an Api instance with `sleep_on_rate_limit=False`, then previously we would not keep track of the data returned in the headers that pertained to the rate limit. My thinking is that there could be a use case where you don't want the Api to sleep for 15 minutes (the default behavior when you're rate limited), but would rather have the program do something else. 

This change has the Api keep track of the rate limit status of any endpoint that the user specifically calls, but won't, on its own, go out and obtain the full rate limit endpoint and doesn't force the user into the default sleeping behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/370)
<!-- Reviewable:end -->
