### PR TITLE
tweet_volume not being populated for Trend objects

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+Version 3.2
+===========
+
+What's Changed
+--------------
+
+* :py:func:`twitter.models.Trend`'s `volume` attribute has been renamed `tweet_volume` in line with Twitter's naming convention. This change should allow users to access the number of tweets being tweeted for a given Trend.
+
 Version 3.1
 ==========
 

--- a/testdata/models/models_trend.json
+++ b/testdata/models/models_trend.json
@@ -1,1 +1,1 @@
-{"name":"#ChangeAConsonantSpoilAMovie","url":"http:\\/\\/twitter.com\\/search?q=%23ChangeAConsonantSpoilAMovie","promoted_content":null,"query":"%23ChangeAConsonantSpoilAMovie","tweet_volume":null}
+{"name":"#ChangeAConsonantSpoilAMovie","url":"http:\\/\\/twitter.com\\/search?q=%23ChangeAConsonantSpoilAMovie","promoted_content":null,"query":"%23ChangeAConsonantSpoilAMovie","tweet_volume":104403}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,6 +117,7 @@ class ModelsTest(unittest.TestCase):
         self.assertTrue(trend.AsJsonString())
         self.assertTrue(trend.AsDict())
         self.assertEqual(trend.tweet_volume, 104403)
+        self.assertEqual(trend.volume, trend.tweet_volume)
 
     def test_url(self):
         url = twitter.Url.NewFromJsonDict(self.URL_SAMPLE_JSON)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,6 +116,7 @@ class ModelsTest(unittest.TestCase):
             self.fail(e)
         self.assertTrue(trend.AsJsonString())
         self.assertTrue(trend.AsDict())
+        self.assertEqual(trend.tweet_volume, 104403)
 
     def test_url(self):
         url = twitter.Url.NewFromJsonDict(self.URL_SAMPLE_JSON)

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -220,6 +220,10 @@ class Trend(TwitterModel):
             self.timestamp,
             self.url)
 
+    @property
+    def volume(self):
+        return self.tweet_volume
+
 
 class Hashtag(TwitterModel):
 

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -208,7 +208,7 @@ class Trend(TwitterModel):
             'query': None,
             'timestamp': None,
             'url': None,
-            'volume': None,
+            'tweet_volume': None,
         }
 
         for (param, default) in self.param_defaults.items():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`Trend.volume` data should be populated on object creation, but because the json data from Twitter is named `tweet_volume`, this isn't occurring. This changes the property name to be `tweet_volume` which conforms with Twitter's naming convention and allows the property to be populated straight from the json data.

Additionally, an `@property` has been added to the `Trend` object for backwards compatibility. 

## Related Issue
#374 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/375)
<!-- Reviewable:end -->
