### PR TITLE
Update makefile for use with pypy and 64 bit linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,13 @@ coverage: clean
 	coverage html
 	coverage report
 
-ci: dev
+ci:
+	pyenv install -s 2.7.11
+	pyenv install -s 3.5.1
+	pyenv install -s pypy-5.3
+	pyenv install -s pypy3-2.4.0
+	pyenv local 2.7.11 3.5.2 pypy-5.3 pypy3-2.4.0
+	pip install -Ur requirements.testing.txt
 	tox
 	CODECOV_TOKEN=`cat .codecov-token` codecov
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 
+ifeq ($(shell uname -m),x86_64)
+PYPY53 = pypy-5.3-src
+else
+PYPY53 = pypy-5.3
+endif
+
 help:
 	@echo "  env         install all production dependencies"
 	@echo "  dev         install all dev and production dependencies (virtualenv is assumed)"
@@ -15,8 +21,8 @@ dev: env
 	pip install -Ur requirements.testing.txt
 	pyenv install -s 2.7.11
 	pyenv install -s 3.5.2
-	pyenv install -s pypy-5.3
-	pyenv local 2.7.11 3.5.2 pypy-5.3
+	pyenv install -s $(PYPY53)
+	pyenv local 2.7.11 3.5.2 $(PYPY53)
 
 info:
 	@python --version

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 
 ifeq ($(shell uname -m),x86_64)
+ifeq ($(shell uname -s),Linux)
 PYPY53 = pypy-5.3-src
 else
 PYPY53 = pypy-5.3
+endif
 endif
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ env:
 
 dev: env
 	pyenv install -s 2.7.11
-	pyenv install -s 3.5.2
-	pyenv install -s pypy-5.4
+	pyenv install -s 3.5.1
+	pyenv install -s pypy-5.3.1
 	pyenv install -s pypy3-2.4.0
-	pyenv local 2.7.11 3.5.2 pypy-5.4 pypy3-2.4.0
+	pyenv local 2.7.11 3.5.1 pypy-5.3.1 pypy3-2.4.0
 	pip install -Ur requirements.testing.txt
 
 info:
@@ -51,9 +51,9 @@ coverage: clean
 ci:
 	pyenv install -s 2.7.11
 	pyenv install -s 3.5.1
-	pyenv install -s pypy-5.3
+	pyenv install -s pypy-5.3.1
 	pyenv install -s pypy3-2.4.0
-	pyenv local 2.7.11 3.5.2 pypy-5.3 pypy3-2.4.0
+	pyenv local 2.7.11 3.5.1 pypy-5.3.1 pypy3-2.4.0
 	pip install -Ur requirements.testing.txt
 	tox
 	CODECOV_TOKEN=`cat .codecov-token` codecov

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,4 @@
 
-ifeq ($(shell uname -m),x86_64)
-ifeq ($(shell uname -s),Linux)
-PYPY53 = pypy-5.3-src
-else
-PYPY53 = pypy-5.3
-endif
-endif
-
 help:
 	@echo "  env         install all production dependencies"
 	@echo "  dev         install all dev and production dependencies (virtualenv is assumed)"
@@ -20,11 +12,12 @@ env:
 	pip install -Ur requirements.txt
 
 dev: env
-	pip install -Ur requirements.testing.txt
 	pyenv install -s 2.7.11
 	pyenv install -s 3.5.2
-	pyenv install -s $(PYPY53)
-	pyenv local 2.7.11 3.5.2 $(PYPY53)
+	pyenv install -s pypy-5.4
+	pyenv install -s pypy3-2.4.0
+	pyenv local 2.7.11 3.5.2 pypy-5.4 pypy3-2.4.0
+	pip install -Ur requirements.testing.txt
 
 info:
 	@python --version
@@ -55,7 +48,8 @@ coverage: clean
 	coverage html
 	coverage report
 
-ci: tox coverage
+ci: dev
+	tox
 	CODECOV_TOKEN=`cat .codecov-token` codecov
 
 build: clean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the `makefile` to get the `uname -m` (returning either "i686" for 32-bit systems or "x86_64" for 64-bit systems) and `uname -s` (returning "Linux" at least on Ubuntu and Arch) and, if it's "x86_64" & "Linux", then use the source distribution of pypy-5.3.

## Related Issue
#378 

## Motivation and Context
Running `make dev` on a 64-bit Linux system results in failure to install pypy-5.3, since only pypy-5.3-src is available for 64-linux.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/379)
<!-- Reviewable:end -->
