### PR TITLE
Fix failure to set unknown rate limit while sleep_on_rate_limit == False

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -141,6 +141,8 @@ class RateLimitMethodsTests(unittest.TestCase):
 
     def testSetRateLimit(self):
         previous_limit = self.api.rate_limit.get_limit('/lists/members')
+        self.assertEqual(previous_limit.remaining, 180)
+
         self.api.rate_limit.set_limit(
             url='https://api.twitter.com/1.1/lists/members.json?skip_status=True',
             limit=previous_limit.limit,
@@ -148,6 +150,8 @@ class RateLimitMethodsTests(unittest.TestCase):
             reset=previous_limit.reset)
         new_limit = self.api.rate_limit.get_limit('/lists/members')
         self.assertEqual(new_limit.remaining, previous_limit.remaining - 1)
+        self.assertEqual(new_limit.limit, previous_limit.limit)
+        self.assertEqual(new_limit.reset, previous_limit.reset)
 
     def testFamilyNotFound(self):
         limit = self.api.rate_limit.get_limit('/tests/test')

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -169,6 +169,16 @@ class RateLimitMethodsTests(unittest.TestCase):
             url='https://api.twitter.com/1.1/not/a/real/endpoint.json')
         self.assertEqual(limit.remaining, 14)
 
+    def testSetUnknownRateLimit(self):
+        self.api.rate_limit.set_unknown_limit(
+            url='https://api.twitter.com/1.1/not/a/real/endpoint.json',
+            limit=15,
+            remaining=14,
+            reset=100)
+        limit = self.api.rate_limit.get_limit(
+            url='https://api.twitter.com/1.1/not/a/real/endpoint.json')
+        self.assertEqual(limit.remaining, 14)
+
     @responses.activate
     def testLimitsViaHeadersNoSleep(self):
         api = twitter.Api(

--- a/twitter/ratelimit.py
+++ b/twitter/ratelimit.py
@@ -121,6 +121,9 @@ class RateLimit(object):
         else:
             return resource
 
+    def set_unknown_limit(self, url, limit, remaining, reset):
+        return self.set_limit(url, limit, remaining, reset)
+
     def set_limit(self, url, limit, remaining, reset):
         """ If a resource family is unknown, add it to the object's
         dictionary. This is to deal with new endpoints being added to

--- a/twitter/ratelimit.py
+++ b/twitter/ratelimit.py
@@ -97,6 +97,7 @@ class RateLimit(object):
         and a dictionary of limit, remaining, and reset will be returned.
 
         """
+        self.__dict__['resources'] = {}
         self.__dict__.update(kwargs)
 
     @staticmethod
@@ -120,7 +121,7 @@ class RateLimit(object):
         else:
             return resource
 
-    def set_unknown_limit(self, url, limit, remaining, reset):
+    def set_limit(self, url, limit, remaining, reset):
         """ If a resource family is unknown, add it to the object's
         dictionary. This is to deal with new endpoints being added to
         the API, but not necessarily to the information returned by
@@ -146,19 +147,18 @@ class RateLimit(object):
         """
         endpoint = self.url_to_resource(url)
         resource_family = endpoint.split('/')[1]
+        new_endpoint = {endpoint: {
+            "limit": enf_type('limit', int, limit),
+            "remaining": enf_type('remaining', int, remaining),
+            "reset": enf_type('reset', int, reset)
+        }}
 
-        # This is a conversative check against a situation in which a user has
-        # set api.sleep_on_rate_limit to True, but hasn't made a call
-        if not self.__dict__.get('resources', None):
-            self.__dict__['resources'] = {}
+        if not self.resources.get(resource_family, None):
+            self.resources[resource_family] = {}
 
-        self.__dict__['resources'].update(
-            {resource_family: {
-                endpoint: {
-                    "limit": limit,
-                    "remaining": remaining,
-                    "reset": reset
-                }}})
+        self.__dict__['resources'][resource_family].update(new_endpoint)
+
+        return self.get_limit(url)
 
     def get_limit(self, url):
         """ Gets a EndpointRateLimit object for the given url.
@@ -183,38 +183,6 @@ class RateLimit(object):
         if not family_rates:
             self.set_unknown_limit(url, limit=15, remaining=15, reset=0)
             return EndpointRateLimit(limit=15, remaining=15, reset=0)
-
-        return EndpointRateLimit(family_rates['limit'],
-                                 family_rates['remaining'],
-                                 family_rates['reset'])
-
-    def set_limit(self, url, limit, remaining, reset):
-        """ Set an endpoint's rate limits. The data used for each of the
-        args should come from Twitter's ``x-rate-limit`` headers.
-
-        Args:
-            url (str):
-                URL of the endpoint being fetched.
-            limit (int):
-                Max number of times a user or app can hit the endpoint
-                before being rate limited.
-            remaining (int):
-                Number of times a user or app can access the endpoint
-                before being rate limited.
-            reset (int):
-                Epoch time at which the rate limit window will reset.
-        """
-        endpoint = self.url_to_resource(url)
-        resource_family = endpoint.split('/')[1]
-
-        try:
-            family_rates = self.resources.get(resource_family).get(endpoint)
-        except AttributeError:
-            self.set_unknown_limit(url, limit, remaining, reset)
-            family_rates = self.resources.get(resource_family).get(endpoint)
-        family_rates['limit'] = enf_type('limit', int, limit)
-        family_rates['remaining'] = enf_type('remaining', int, remaining)
-        family_rates['reset'] = enf_type('reset', int, reset)
 
         return EndpointRateLimit(family_rates['limit'],
                                  family_rates['remaining'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Setting `sleep_on_rate_limit` to `False` would cause the API to raise an exception by attempting to assign a value to `None` as though it were a dictionary. This was cause by the `rate_limit.set_limit` code not properly handling a case were an exception wasn't raised on

```python
try:
    family_rates = self.resources.get(resource_family).get(endpoint)  # <-- this here.
except AttributeError:
    self.set_unknown_limit(url, limit, remaining, reset)
family_rates = self.resources.get(resource_family).get(endpoint)
```
so `family_rates` would just be set to `None`, so when this
```python
family_rates['limit'] = enf_type('limit', int, limit)
```
happened, it'd raise a TypeError trying to set the `'limit'` attribute on a NoneType object.

Long story short, I deleted the offending `set_limit` code after realizing that `set_limit` and `set_unknown_limit` did the same thing, except `set_unknown_limit` didn't screw it up. (It makes no difference to the `rate_limit.resources` dict if you're creating a new limit or updating an old one so long as  `rate_limit.resources[<resource_family>]` exists and since we can check for that prior to attempting to set it, we can obviate the need for the whole `set_limit` / `set_unknown_limit` rigamarole.) Those methods being combined, `set_unknown_limit` got renamed to `set_limit` and `set_unknown_limit` is just a stub for what's now `set_limit` to maintain compatibility (since `set_unknown_limit` was technically a public method of `Api.RateLimit`.

## Related Issue
#380 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change does not require a change to the documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/381)
<!-- Reviewable:end -->
