### PR TITLE
Added Google's monkeypatch, disabled caching for now.

### DIFF
--- a/GAE.rst
+++ b/GAE.rst
@@ -49,3 +49,7 @@ When using twitter-python on App Engine, caching is disabled. You'll have to add
 Datastore
 ^^^^^^^^^
 If you plan to store tweets or other information returned by the API in Datastore, you'll probably want to make your own NDP models to store the desired components of the response rather than shoving the whole response into an entity.
+
+Sockets
+^^^^^^^^^
+When urllib3 is imported on App Engine it will throw a warning about sockets: ``AppEnginePlatformWarning: urllib3 is using URLFetch on Google App Engine sandbox...`` This is just a warning that you'd have to use the Sockets API if you intend to use the sockets feature of the library, which we don't use in python-twitter so it can be ignored.

--- a/GAE.rst
+++ b/GAE.rst
@@ -1,0 +1,51 @@
+================================================
+How to use python-twitter with Google App Engine
+================================================
+
+**********
+Background
+**********
+
+Google App Engine uses virtual machines to do work and serve your application's content. In order to make a 'regular' external web request, the instance must use the built-in urlfetch library provided by Google in addition to the traditional python requests library. As a result, a few extra steps must be followed to use python-twitter on App Engine.
+
+
+*************
+Prerequisites
+*************
+
+Follow the `third party vendor library install instructions <https://cloud.google.com/appengine/docs/python/tools/using-libraries-python-27#vendoring>`_ to include the two dependency libraries listed in ``requirements.txt``: ``requests`` and ``requests_oauthlib``, as well as this ``python-twitter`` library. Typically you can just place the three module folders into the same place as your app.yaml file; it might look something like this:
+
+| myapp/
+| ├── twitter/
+| ├── requests_oauthlib/
+| ├── requests_toolbelt/
+| ├── main.py 
+| └── app.yaml
+
+
+********
+app.yaml
+********
+
+In order to use HTTPS, you'll have to make sure the built-in SSL library is properly imported in your ``app.yaml`` file. Here's what that section of your ``app.yaml`` file might look like:
+
+| libraries:
+| - name: jinja2
+|  version: latest
+| - name: webapp2
+|  version: latest
+| - name: ssl
+|  version: latest
+
+
+****************************
+Limitations & Considerations
+****************************
+
+Caching
+^^^^^^^
+When using twitter-python on App Engine, caching is disabled. You'll have to add and manage App Engine's memcache logic on your own if you require any caching beyond what is probably already setup on App Engine by default.
+
+Datastore
+^^^^^^^^^
+If you plan to store tweets or other information returned by the API in Datastore, you'll probably want to make your own NDP models to store the desired components of the response rather than shoving the whole response into an entity.

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,10 @@ You can install python-twitter using::
 
     $ pip install python-twitter
 
+	
+If you are using python-twitter on Google App Engine, see `more information <GAE.rst>`_ about including 3rd party vendor library dependencies in your App Engine project.
+
+
 ================
 Getting the code
 ================

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -178,7 +178,7 @@ class Api(object):
 
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
-        if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+        if os.environ and  'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
             import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
             requests_toolbelt.adapters.appengine.monkeypatch()
             cache = None  # App Engine does not like this caching strategy, disable caching

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -178,7 +178,7 @@ class Api(object):
 
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
-        if os.environ and 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+        if os.environ and 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', False):
             import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
             requests_toolbelt.adapters.appengine.monkeypatch()
             cache = None  # App Engine does not like this caching strategy, disable caching

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -26,6 +26,9 @@ import time
 import base64
 import re
 import requests
+import requests_toolbelt.adapters.appengine
+# App Engine Requests adapter. This makes sure that Requests uses URLFetch.
+requests_toolbelt.adapters.appengine.monkeypatch()
 from requests_oauthlib import OAuth1
 import io
 import warnings
@@ -4596,6 +4599,7 @@ class Api(object):
           cache:
             An instance that supports the same API as the twitter._FileCache
         """
+        cache = None # App Engine does not like this caching strategy, disable caching.
         if cache == DEFAULT_CACHE:
             self._cache = _FileCache()
         else:

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -27,8 +27,6 @@ import base64
 import re
 import requests
 import requests_toolbelt.adapters.appengine
-# App Engine Requests adapter. This makes sure that Requests uses URLFetch.
-requests_toolbelt.adapters.appengine.monkeypatch()
 from requests_oauthlib import OAuth1
 import io
 import warnings
@@ -55,6 +53,9 @@ from twitter.twitter_utils import (
     is_url,
     parse_media_file,
     enf_type)
+
+# App Engine Requests adapter. This makes sure that Requests uses URLFetch.
+requests_toolbelt.adapters.appengine.monkeypatch()
 
 warnings.simplefilter('always', DeprecationWarning)
 
@@ -4599,7 +4600,8 @@ class Api(object):
           cache:
             An instance that supports the same API as the twitter._FileCache
         """
-        cache = None # App Engine does not like this caching strategy, disable caching.
+        # App Engine does not like this caching strategy, disable caching.
+        cache = None
         if cache == DEFAULT_CACHE:
             self._cache = _FileCache()
         else:

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -178,10 +178,11 @@ class Api(object):
 
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
-        if os.environ and 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', False):
-            import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
-            requests_toolbelt.adapters.appengine.monkeypatch()
-            cache = None  # App Engine does not like this caching strategy, disable caching
+        if os.environ:
+			if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+				import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
+				requests_toolbelt.adapters.appengine.monkeypatch()
+				cache = None  # App Engine does not like this caching strategy, disable caching
 
         self.SetCache(cache)
         self._cache_timeout = Api.DEFAULT_CACHE_TIMEOUT

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -179,7 +179,7 @@ class Api(object):
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
         if os.environ:
-            if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+            if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', ''):
                 import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
                 requests_toolbelt.adapters.appengine.monkeypatch()
                 cache = None  # App Engine does not like this caching strategy, disable caching

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -178,7 +178,7 @@ class Api(object):
 
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
-        if os.environ and  'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+        if os.environ and 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
             import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
             requests_toolbelt.adapters.appengine.monkeypatch()
             cache = None  # App Engine does not like this caching strategy, disable caching

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -179,10 +179,10 @@ class Api(object):
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
         if os.environ:
-			if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
-				import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
-				requests_toolbelt.adapters.appengine.monkeypatch()
-				cache = None  # App Engine does not like this caching strategy, disable caching
+            if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
+                import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
+                requests_toolbelt.adapters.appengine.monkeypatch()
+                cache = None  # App Engine does not like this caching strategy, disable caching
 
         self.SetCache(cache)
         self._cache_timeout = Api.DEFAULT_CACHE_TIMEOUT

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -178,7 +178,7 @@ class Api(object):
 
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
-        if 'Google App Engine' in os.environ['SERVER_SOFTWARE']:
+        if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', None):
             import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
             requests_toolbelt.adapters.appengine.monkeypatch()
             cache = None  # App Engine does not like this caching strategy, disable caching


### PR DESCRIPTION
Added Google's monkeypatch so requests will use the appengine urlfetch library. Disabled caching for now because app engine does not work with the existing strategy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/383)
<!-- Reviewable:end -->
