### PR TITLE
Add User object to DMs per Issue #344

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,10 +4,41 @@ Changelog
 Version 3.2
 ===========
 
+What's New
+----------
+
+* :py:class:`twitter.models.User` now contains a ``following`` attribute, which describes whether the authenticated user is following the User. `PR #351 <https://github.com/bear/python-twitter/pull/351>`_
+
+* :py:class:`twitter.models.DirectMessage` now contains a full :py:class:`twitter.models.User` object for both the ``DirectMessage.sender`` and ``DirectMessage.recipient`` properties. `PR #384 <https://github.com/bear/python-twitter/pull/384>`_.
+
+* You can now upload Quicktime movies (``*.mov``). `PR #372 <https://github.com/bear/python-twitter/pull/372>`_.
+
+* If you have a whitelisted app, you can now get the authenticated user's email address through a call to :py:func:`twitter.api.Api.VerifyCredentials()`. If your app isn't whitelisted, no error is returned. `PR #376 <https://github.com/bear/python-twitter/pull/376>`_.
+
+* **Google App Engine support has been reintegrated into the library!** Check out `PR #383 <https://github.com/bear/python-twitter/pull/383>`_.
+
 What's Changed
 --------------
 
-* :py:func:`twitter.models.Trend`'s `volume` attribute has been renamed `tweet_volume` in line with Twitter's naming convention. This change should allow users to access the number of tweets being tweeted for a given Trend.
+* :py:class:`twitter.models.Trend`'s `volume` attribute has been renamed `tweet_volume` in line with Twitter's naming convention. This change should allow users to access the number of tweets being tweeted for a given Trend. `PR #375 <https://github.com/bear/python-twitter/pull/375>`_
+
+* :py:class:`twitter.ratelimit.RateLimit` should behave better now and adds a 1-second padding to requests after sleeping.
+
+* :py:class:`twitter.ratelimit.RateLimit` now keeps track of your rate limit status even if you don't have ``sleep_on_rate_limit`` set to ``True`` when instatiating the API. If you want to add different behavior on hitting a rate limit, you should be able to now by querying the rate limit object. See `PR #370 <https://github.com/bear/python-twitter/pull/370>`_ for the technical details of the change. There should be no difference in behavior for the defaults, but let us know.
+
+
+Bugfixes
+--------
+
+* :py:class:`twitter.models.Media` again contains a ``sizes`` attribute, which was missed back in the Version 3.0 release. `PR #360 <https://github.com/bear/python-twitter/pull/360>`_
+
+* The previously bloated :py:func:`twitter.api.Api.UploadMediaChunked()` function has been broken out into three related functions and fixes two an incompatibility with python 2.7. Behavior remains the same, but this should simplify matters. `PR #347 <https://github.com/bear/python-twitter/pull/347>`_
+
+* Fix for :py:func:`twitter.api.Api.PostUpdate()` where a passing an integer to the ``media`` parameter would cause an iteration error to occur. `PR #347 <https://github.com/bear/python-twitter/pull/347>`_
+
+* Fix for 401 errors that were occuring in the Streaming Endpoints. `PR #364 <https://github.com/bear/python-twitter/pull/364>`_
+
+
 
 Version 3.1
 ==========

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,6 +52,12 @@ class ModelsTest(unittest.TestCase):
         self.assertTrue(dm.AsJsonString())
         self.assertTrue(dm.AsDict())
 
+    def test_direct_message_sender_is_user_model(self):
+        """Test that each Direct Message object contains a fully hydrated
+        twitter.models.User object for both ``dm.sender`` & ``dm.recipient``."""
+        dm = twitter.DirectMessage.NewFromJsonDict(self.DIRECT_MESSAGE_SAMPLE_JSON)
+        self.assertTrue(isinstance(dm.sender, twitter.models.User))
+
     def test_hashtag(self):
         """ Test twitter.Hashtag object """
         ht = twitter.Hashtag.NewFromJsonDict(self.HASHTAG_SAMPLE_JSON)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,23 @@ class ModelsTest(unittest.TestCase):
         """Test that each Direct Message object contains a fully hydrated
         twitter.models.User object for both ``dm.sender`` & ``dm.recipient``."""
         dm = twitter.DirectMessage.NewFromJsonDict(self.DIRECT_MESSAGE_SAMPLE_JSON)
+
         self.assertTrue(isinstance(dm.sender, twitter.models.User))
+        self.assertEqual(dm.sender.id, 372018022)
+
+        # Let's make sure this doesn't break the construction of the DM object.
+        self.assertEqual(dm.id, 678629245946433539)
+
+    def test_direct_message_recipient_is_user_model(self):
+        """Test that each Direct Message object contains a fully hydrated
+        twitter.models.User object for both ``dm.sender`` & ``dm.recipient``."""
+        dm = twitter.DirectMessage.NewFromJsonDict(self.DIRECT_MESSAGE_SAMPLE_JSON)
+
+        self.assertTrue(isinstance(dm.recipient, twitter.models.User))
+        self.assertEqual(dm.recipient.id, 4012966701)
+
+        # Same as above.
+        self.assertEqual(dm.id, 678629245946433539)
 
     def test_hashtag(self):
         """ Test twitter.Hashtag object """

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -176,6 +176,7 @@ class DirectMessage(TwitterModel):
             'id': None,
             'recipient_id': None,
             'recipient_screen_name': None,
+            'sender': None,
             'sender_id': None,
             'sender_screen_name': None,
             'text': None,
@@ -183,6 +184,8 @@ class DirectMessage(TwitterModel):
 
         for (param, default) in self.param_defaults.items():
             setattr(self, param, kwargs.get(param, default))
+        if 'sender' in kwargs:
+            self.sender = User.NewFromJsonDict(kwargs.get('sender', None))
 
     def __repr__(self):
         if self.text and len(self.text) > 140:

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -174,6 +174,7 @@ class DirectMessage(TwitterModel):
         self.param_defaults = {
             'created_at': None,
             'id': None,
+            'recipient': None,
             'recipient_id': None,
             'recipient_screen_name': None,
             'sender': None,
@@ -186,6 +187,8 @@ class DirectMessage(TwitterModel):
             setattr(self, param, kwargs.get(param, default))
         if 'sender' in kwargs:
             self.sender = User.NewFromJsonDict(kwargs.get('sender', None))
+        if 'recipient' in kwargs:
+            self.recipient = User.NewFromJsonDict(kwargs.get('recipient', None))
 
     def __repr__(self):
         if self.text and len(self.text) > 140:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a full-hydrated User object to the DirectMessage object for the ``sender`` and ``recipient`` properties.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#344 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added for DirectMessage Model. All prior tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/384)
<!-- Reviewable:end -->
