### PR TITLE
Add support for non-ascii filenames in UploadMediaChunked

### DIFF
--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -1703,6 +1703,18 @@ class ApiTest(unittest.TestCase):
         self.assertTrue(resp)
 
     @responses.activate
+    def testPostUploadMediaChunkedAppendNonASCIIFilename(self):
+        media_fp, filename, _, _ = twitter.twitter_utils.parse_media_file(
+            'testdata/corgi.gif')
+        filename = "عَرَبِيّ"
+        responses.add(responses.POST, DEFAULT_URL, body='', status=200)
+
+        resp = self.api._UploadMediaChunkedAppend(media_id=737956420046356480,
+                                                  media_fp=media_fp,
+                                                  filename=filename)
+        self.assertEqual(len(responses.calls), 7)
+
+    @responses.activate
     def testPostUploadMediaChunkedFinalize(self):
         with open('testdata/post_upload_chunked_FINAL.json') as f:
             resp_data = f.read()

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1185,7 +1185,7 @@ class Api(object):
                 b'',
                 str(segment_id).encode('utf-8'),
                 boundary,
-                'Content-Disposition: form-data; name="media"; filename="{0}"'.format(filename).encode('utf8'),
+                'Content-Disposition: form-data; name="media"; filename="{0!r}"'.format(filename).encode('utf8'),
                 b'Content-Type: application/octet-stream',
                 b'',
                 data,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/389)
<!-- Reviewable:end -->
