### PR TITLE
Update GAE environ test

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -210,7 +210,7 @@ class Api(object):
         # check to see if the library is running on a Google App Engine instance
         # see GAE.rst for more information
         if os.environ:
-            if 'Google App Engine' in os.environ.get('SERVER_SOFTWARE', ''):
+            if 'APPENGINE_RUNTIME' in os.environ.keys():
                 import requests_toolbelt.adapters.appengine  # Adapter ensures requests use app engine's urlfetch
                 requests_toolbelt.adapters.appengine.monkeypatch()
                 cache = None  # App Engine does not like this caching strategy, disable caching


### PR DESCRIPTION
The value of os.environ.get('SERVER_SOFTWARE', '') only contains 'Google App Engine' when running on production. Local dev environments have a value like 'Development/X.Y'. Because of that, I was getting cache errors when running locally.

Instead of testing the value of the 'SERVER_SOFTWARE' key, testing for the presence of an 'APPENGINE_RUNTIME' key will work across both local and production environments.

(This is my first ever pull request for an open source project. Apologies if there's etiquette I've not followed.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/436)
<!-- Reviewable:end -->
