### PR TITLE
Fix to upload video/gifs to correct endpoint if filesize < self.chunk_size

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1026,6 +1026,7 @@ class Api(object):
             parameters['attachment_url'] = attachment_url
 
         if media:
+            chunked_types = ['video/mp4', 'video/quicktime', 'image/gif']
             media_ids = []
             if isinstance(media, int):
                 media_ids.append(media)
@@ -1041,9 +1042,8 @@ class Api(object):
                     _, _, file_size, media_type = parse_media_file(media_file)
                     if media_type == 'image/gif' or media_type == 'video/mp4':
                         raise TwitterError(
-                            'You cannot post more than 1 GIF or 1 video in a '
-                            'single status.')
-                    if file_size > self.chunk_size:
+                            'You cannot post more than 1 GIF or 1 video in a single status.')
+                    if file_size > self.chunk_size or media_type in chunked_types:
                         media_id = self.UploadMediaChunked(
                             media=media_file,
                             additional_owners=media_additional_owners,
@@ -1055,13 +1055,11 @@ class Api(object):
                             media_category=media_category)
                     media_ids.append(media_id)
             else:
-                _, _, file_size, _ = parse_media_file(media)
-                if file_size > self.chunk_size:
-                    media_ids.append(
-                        self.UploadMediaChunked(media, media_additional_owners))
+                _, _, file_size, media_type = parse_media_file(media)
+                if file_size > self.chunk_size or media_type in chunked_types:
+                    media_ids.append(self.UploadMediaChunked(media, media_additional_owners))
                 else:
-                    media_ids.append(
-                        self.UploadMediaSimple(media, media_additional_owners))
+                    media_ids.append(self.UploadMediaSimple(media, media_additional_owners))
             parameters['media_ids'] = ','.join([str(mid) for mid in media_ids])
 
         if latitude is not None and longitude is not None:
@@ -1263,7 +1261,7 @@ class Api(object):
 
         try:
             media_fp.close()
-        except:
+        except Exception as e:
             pass
 
         return True

--- a/twitter/twitter_utils.py
+++ b/twitter/twitter_utils.py
@@ -223,8 +223,8 @@ def parse_media_file(passed_media):
     # Otherwise, if a file object was passed in the first place,
     # create the standard reference to media_file (i.e., rename it to fp).
     else:
-        if passed_media.mode != 'rb':
-            raise TwitterError({'message': 'File mode must be "rb".'})
+        if passed_media.mode not in ['rb', 'rb+', 'w+b']:
+            raise TwitterError('File mode must be "rb" or "rb+"')
         filename = os.path.basename(passed_media.name)
         data_file = passed_media
 
@@ -233,7 +233,7 @@ def parse_media_file(passed_media):
 
     try:
         data_file.seek(0)
-    except:
+    except Exception as e:
         pass
 
     media_type = mimetypes.guess_type(os.path.basename(filename))[0]


### PR DESCRIPTION
Previously, if a GIF or a video was less than `self.chunk_size`, it would be uploaded via `UploadMediaSimple`, but this was a bug because that endpoint cannot handle videos or GIFs. This change makes it so that even if the video is small, it'll get passed to `UploadMediaChunked`.

Closes #433. All tests pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/439)
<!-- Reviewable:end -->
