### PR TITLE
Fix warnings always being displayed at library level

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -70,8 +70,6 @@ from twitter.error import (
 )
 
 
-warnings.simplefilter('always', DeprecationWarning)
-
 CHARACTER_LIMIT = 140
 
 # A singleton representing a lazily instantiated FileCache.


### PR DESCRIPTION
We were previously surfacing all warnings by setting `warnings.simplefilter` in the source of python-twitter itself. It seems like this is a decision best left to the end user whether and how (if they just want to see the warning or if they want to error out) they would like them handled. This removes that line of code.

Closes issue #403 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/440)
<!-- Reviewable:end -->
