### PR TITLE
Change retweeters parameter to 'cursor'

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1708,7 +1708,7 @@ class Api(object):
         while True:
             if cursor:
                 try:
-                    parameters['count'] = int(cursor)
+                    parameters['cursor'] = int(cursor)
                 except ValueError:
                     raise TwitterError({'message': "cursor must be an integer"})
             resp = self._RequestUrl(url, 'GET', data=parameters)


### PR DESCRIPTION
According to the documentation (https://dev.twitter.com/rest/reference/get/statuses/retweeters/ids)
the cursoring parameter is called 'cursor' and not 'count'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/451)
<!-- Reviewable:end -->
