### PR TITLE
fix for case where media_id was long in PostUpdate isinstance check

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -69,6 +69,8 @@ from twitter.error import (
     PythonTwitterDeprecationWarning330,
 )
 
+if sys.version_info > (3,):
+    long = int
 
 CHARACTER_LIMIT = 140
 
@@ -1060,14 +1062,14 @@ class Api(object):
         if media:
             chunked_types = ['video/mp4', 'video/quicktime', 'image/gif']
             media_ids = []
-            if isinstance(media, int):
+            if isinstance(media, (int, long)):
                 media_ids.append(media)
 
             elif isinstance(media, list):
                 for media_file in media:
 
                     # If you want to pass just a media ID, it should be an int
-                    if isinstance(media_file, int):
+                    if isinstance(media_file, (int, long)):
                         media_ids.append(media_file)
                         continue
 


### PR DESCRIPTION
If `media_id` was a `long` in python 2.7, then the `isinstance` checks `ints` would fail, causing problems for attaching a media object to a tweet.

Closes issue #438

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/463)
<!-- Reviewable:end -->
