### PR TITLE
Add api.Replyto for convenience

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4693,8 +4693,10 @@ class Api(object):
 
         return User.NewFromJsonDict(data)
 
-    def RelayTo(self, status, in_reply_to_status_id, **kwargs):
-        """Relay to a status. Automatically add @username before the status for convenience.
+    def ReplyTo(self, status, in_reply_to_status_id, **kwargs):
+        """Relay to a status. Automatically add @username before the status for 
+        convenience.This method calls api.GetStatus to get username.
+        
 
         Args:
             status (str):

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4693,6 +4693,30 @@ class Api(object):
 
         return User.NewFromJsonDict(data)
 
+    def RelayTo(self, status, in_reply_to_status_id, **kwargs):
+        """Relay to a status. Automatically add @username before the status for convenience.
+
+        Args:
+            status (str):
+                The message text to be replyed.Must be less than or equal to 140 characters.
+            in_reply_to_status_id (int):
+                The ID of an existing status that the status to be posted is in reply to.
+            **kwargs:
+                The other args api.PostUpadtes need.
+
+        Returns:
+            (twitter.Status) A twitter.Status instance representing the message replied.
+        """
+        reply_status = self.GetStatus(in_reply_to_status_id)
+        u_status = "@%s " % reply_status.user.screen_name
+        if isinstance(status, str) or self._input_encoding is None:
+            u_status = u_status + status
+        else:
+            u_status = u_status + str(u_status, self._input_encoding)
+
+        return self.PostUpdate(u_status, in_reply_to_status_id=in_reply_to_status_id, **kwargs)
+
+
     def SetCache(self, cache):
         """Override the default cache.  Set to None to prevent caching.
 


### PR DESCRIPTION
According to twitter's api:

> Note: This parameter(in_reply_to_status_id) will be ignored unless the author of the Tweet this parameter references is mentioned within the status text. Therefore, you must include @username , where username is the author of the referenced Tweet, within the update.

user only specify in_reply_to_status_id arguement in api.PostUpadte may not work. api.Replyto automatically  add _@username_ before the message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/487)
<!-- Reviewable:end -->
