### PR TITLE
Fix `include_email` parameter of VerifyCredentials

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4685,7 +4685,7 @@ class Api(object):
         data = {
             'include_entities': enf_type('include_entities', bool, include_entities),
             'skip_status': enf_type('skip_status', bool, skip_status),
-            'include_email': enf_type('include_email', bool, include_email)
+            'include_email': 'true' if enf_type('include_email', bool, include_email) else 'false',
         }
 
         resp = self._RequestUrl(url, 'GET', data)


### PR DESCRIPTION
Because it seems we have to pass 'true'(not 'True') for the parameter to get `email` field in the response

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/493)
<!-- Reviewable:end -->
