### PR TITLE
Removed 140 character limit from Api.PostDirectMessage method's doc

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -3088,7 +3088,7 @@ class Api(object):
         """Post a twitter direct message from the authenticated user.
 
         Args:
-          text: The message text to be posted.  Must be less than 140 characters.
+          text: The message text to be posted.
           user_id:
             The ID of the user who should receive the direct message. [Optional]
           screen_name:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/505)
<!-- Reviewable:end -->
