### PR TITLE
Fix issue #494 for py3 compat w/ app only auth

### DIFF
--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -89,6 +89,17 @@ class ApiTest(unittest.TestCase):
         self.assertRaises(twitter.TwitterError, lambda: api.GetFollowers())
 
     @responses.activate
+    def testAppOnlyAuth(self):
+        responses.add(method=POST,
+                      url='https://api.twitter.com/oauth2/token',
+                      body='{"token_type":"bearer","access_token":"testing"}')
+        api = twitter.Api(
+            consumer_key='test',
+            consumer_secret='test',
+            application_only_auth=True)
+        self.assertEqual(api._bearer_token['access_token'], "testing")
+
+    @responses.activate
     def testGetHelpConfiguration(self):
         with open('testdata/get_help_configuration.json') as f:
             resp_data = f.read()

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -35,13 +35,13 @@ import os
 
 try:
     # python 3
-    from urllib.parse import urlparse, urlunparse, urlencode
+    from urllib.parse import urlparse, urlunparse, urlencode, quote_plus
     from urllib.request import urlopen
     from urllib.request import __version__ as urllib_version
 except ImportError:
     from urlparse import urlparse, urlunparse
     from urllib2 import urlopen
-    from urllib import urlencode
+    from urllib import urlencode, quote_plus
     from urllib import __version__ as urllib_version
 
 from twitter import (
@@ -288,17 +288,15 @@ class Api(object):
         """
         Generate a Bearer Token from consumer_key and consumer_secret
         """
-        from urllib import quote_plus
-        import base64
-
         key = quote_plus(consumer_key)
         secret = quote_plus(consumer_secret)
-        bearer_token = base64.b64encode('{}:{}'.format(key, secret))
+        bearer_token = base64.b64encode('{}:{}'.format(key, secret).encode('utf8'))
 
         post_headers = {
-            'Authorization': 'Basic ' + bearer_token,
+            'Authorization': 'Basic {0}'.format(bearer_token.decode('utf8')),
             'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
         }
+
         res = requests.post(url='https://api.twitter.com/oauth2/token',
                             data={'grant_type': 'client_credentials'},
                             headers=post_headers)


### PR DESCRIPTION
- Fixes imports for py2/py3 with urllib.quote_plus
- Fixes issue with implicit string/bytes conversion with the headers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/508)
<!-- Reviewable:end -->
