### PR TITLE
move UserStatus.connections to private class attr

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,3 +190,7 @@ class ModelsTest(unittest.TestCase):
             self.fail(e)
         self.assertTrue(user_status.AsJsonString())
         self.assertTrue(user_status.AsDict())
+
+        self.assertTrue(user_status.connections['blocking'])
+        self.assertTrue(user_status.connections['muting'])
+        self.assertFalse(user_status.connections['followed_by'])

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -321,7 +321,7 @@ class UserStatus(TwitterModel):
                 'muting': self.muting}
 
     def __repr__(self):
-        connections = [param for param in self._connections if getattr(self, param)]
+        connections = [param for param in self.connections if getattr(self, param)]
         return "UserStatus(ID={uid}, ScreenName={sn}, Connections=[{conn}])".format(
             uid=self.id,
             sn=self.screen_name,

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -282,12 +282,12 @@ class UserStatus(TwitterModel):
     """ A class representing the UserStatus structure. This is an abbreviated
     form of the twitter.User object. """
 
-    connections = {'following': False,
-                   'followed_by': False,
-                   'following_received': False,
-                   'following_requested': False,
-                   'blocking': False,
-                   'muting': False}
+    _connections = {'following': False,
+                    'followed_by': False,
+                    'following_received': False,
+                    'following_requested': False,
+                    'blocking': False,
+                    'muting': False}
 
     def __init__(self, **kwargs):
         self.param_defaults = {
@@ -307,12 +307,21 @@ class UserStatus(TwitterModel):
             setattr(self, param, kwargs.get(param, default))
 
         if 'connections' in kwargs:
-            for param in self.connections:
+            for param in self._connections:
                 if param in kwargs['connections']:
                     setattr(self, param, True)
 
+    @property
+    def connections(self):
+        return {'following': self.following,
+                'followed_by': self.followed_by,
+                'following_received': self.following_received,
+                'following_requested': self.following_requested,
+                'blocking': self.blocking,
+                'muting': self.muting}
+
     def __repr__(self):
-        connections = [param for param in self.connections if getattr(self, param)]
+        connections = [param for param in self._connections if getattr(self, param)]
         return "UserStatus(ID={uid}, ScreenName={sn}, Connections=[{conn}])".format(
             uid=self.id,
             sn=self.screen_name,


### PR DESCRIPTION
Because `UserStatus.connections` is a public variable, there is some confusion regarding its use (see #497). The original idea was that `UserStatus.connections` would only hold the default connection types available, much like the `param_defaults` attribute for other models; however, because of the name, it was implied that this attribute contained the connections for the specific instance, resulting in confusion between it and the intended attributes (i.e., `UserStatus.followed_by` etc).

This commit moves the attribute to a private attribute (`._connections`) so that it is clearer to end-users that it should not be used for a specific instance.

Additionally, this creates an `@property` with a dictionary containing the class-specific attributes for `UserStatus.following`, etc. to maintain backwards compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/510)
<!-- Reviewable:end -->
