### PR TITLE
increasing delta time to sleep

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -5051,7 +5051,7 @@ class Api(object):
 
                 if limit.remaining == 0:
                     try:
-                        time.sleep(max(int(limit.reset - time.time()) + 2, 0))
+                        time.sleep(max(int(limit.reset - time.time()) + 10, 0))
                     except ValueError:
                         pass
 


### PR DESCRIPTION
2 seconds delta was not sufficient. It was throwing errors once the sleep is over. 
I have kept it at 10 seconds. 
This value either needs to be asked at the time of object creation or needs to be based on some stats rather than random selection. 

Will be more than happy to hear comments and suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/542)
<!-- Reviewable:end -->
