### PR TITLE
Logging ratelimit

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -230,7 +230,7 @@ class Api(object):
         self._debugHTTP = debugHTTP
         self._shortlink_size = 19
         if timeout and timeout < 30:
-            warn("Warning: The Twitter streaming API sends 30s keepalives, the given timeout is shorter!")
+            warnings.warn("Warning: The Twitter streaming API sends 30s keepalives, the given timeout is shorter!")
         self._timeout = timeout
         self.__auth = None
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -26,6 +26,7 @@ import gzip
 import time
 import base64
 import re
+import logging
 import requests
 from requests_oauthlib import OAuth1, OAuth2
 import io
@@ -77,6 +78,7 @@ CHARACTER_LIMIT = 280
 # A singleton representing a lazily instantiated FileCache.
 DEFAULT_CACHE = object()
 
+logger = logging.getLogger(__name__)
 
 class Api(object):
     """A python interface into the Twitter API
@@ -275,7 +277,6 @@ class Api(object):
                             application_only_auth)
 
         if debugHTTP:
-            import logging
             try:
                 import http.client as http_client  # python3
             except ImportError:
@@ -5051,7 +5052,9 @@ class Api(object):
 
                 if limit.remaining == 0:
                     try:
-                        time.sleep(max(int(limit.reset - time.time()) + 2, 0))
+                        stime = max(int(limit.reset - time.time()) + 2, 0)
+                        logger.debug('Rate limited requesting [%s], sleeping for [%s]', url, stime)
+                        time.sleep(stime)
                     except ValueError:
                         pass
 


### PR DESCRIPTION
Add a local logger to api.py.
Use that logger to log a debug message when the user has been ratelimited.
Add a test which covers the time.sleep code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/544)
<!-- Reviewable:end -->
