### PR TITLE
twitter.Api - SSL Certificate Verification

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -162,7 +162,9 @@ class Api(object):
                  timeout=None,
                  sleep_on_rate_limit=False,
                  tweet_mode='compat',
-                 proxies=None):
+                 proxies=None,
+				 verify_ssl=None,
+				 cert_ssl=None):
         """Instantiate a new twitter.Api object.
 
         Args:
@@ -216,6 +218,13 @@ class Api(object):
           proxies (dict, optional):
             A dictionary of proxies for the request to pass through, if not specified
             allows requests lib to use environmental variables for proxy if any.
+		  verify_ssl (optional):
+		    Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use. Defaults to ``True``.
+          cert_ssl (optional):
+            If String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair.
         """
 
         # check to see if the library is running on a Google App Engine instance
@@ -247,6 +256,8 @@ class Api(object):
         self.sleep_on_rate_limit = sleep_on_rate_limit
         self.tweet_mode = tweet_mode
         self.proxies = proxies
+        self.verify_ssl = verify_ssl
+        self.cert_ssl = cert_ssl
 
         if base_url is None:
             self.base_url = 'https://api.twitter.com/1.1'
@@ -4913,7 +4924,9 @@ class Api(object):
                 data=data,
                 auth=self.__auth,
                 timeout=self._timeout,
-                proxies=self.proxies
+                proxies=self.proxies,
+                verify=self.verify_ssl,
+				cert=self.cert_ssl
             )
         except requests.RequestException as e:
             raise TwitterError(str(e))
@@ -4954,20 +4967,20 @@ class Api(object):
             if data:
                 if 'media_ids' in data:
                     url = self._BuildUrl(url, extra_params={'media_ids': data['media_ids']})
-                    resp = requests.post(url, data=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
+                    resp = requests.post(url, data=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies, verify=self.verify_ssl, cert=self.cert_ssl)
                 elif 'media' in data:
-                    resp = requests.post(url, files=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
+                    resp = requests.post(url, files=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies, verify=self.verify_ssl, cert=self.cert_ssl)
                 else:
-                    resp = requests.post(url, data=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
+                    resp = requests.post(url, data=data, auth=self.__auth, timeout=self._timeout, proxies=self.proxies, verify=self.verify_ssl, cert=self.cert_ssl)
             elif json:
-                resp = requests.post(url, json=json, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
+                resp = requests.post(url, json=json, auth=self.__auth, timeout=self._timeout, proxies=self.proxies, verify=self.verify_ssl, cert=self.cert_ssl)
             else:
                 resp = 0  # POST request, but without data or json
 
         elif verb == 'GET':
             data['tweet_mode'] = self.tweet_mode
             url = self._BuildUrl(url, extra_params=data)
-            resp = requests.get(url, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
+            resp = requests.get(url, auth=self.__auth, timeout=self._timeout, proxies=self.proxies, verify=self.verify_ssl, cert=self.cert_ssl)
 
         else:
             resp = 0  # if not a POST or GET request
@@ -5002,14 +5015,17 @@ class Api(object):
                 return session.post(url, data=data, stream=True,
                                     auth=self.__auth,
                                     timeout=self._timeout,
-                                    proxies=self.proxies)
+                                    proxies=self.proxies,
+                                    verify=self.verify_ssl,
+                                    cert=self.cert_ssl)
             except requests.RequestException as e:
                 raise TwitterError(str(e))
         if verb == 'GET':
             url = self._BuildUrl(url, extra_params=data)
             try:
                 return session.get(url, stream=True, auth=self.__auth,
-                                   timeout=self._timeout, proxies=self.proxies)
+                                   timeout=self._timeout, proxies=self.proxies,
+                                   verify=self.verify_ssl, cert=self.cert_ssl)
             except requests.RequestException as e:
                 raise TwitterError(str(e))
         return 0  # if not a POST or GET request

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -163,8 +163,8 @@ class Api(object):
                  sleep_on_rate_limit=False,
                  tweet_mode='compat',
                  proxies=None,
-				 verify_ssl=None,
-				 cert_ssl=None):
+                 verify_ssl=None,
+                 cert_ssl=None):
         """Instantiate a new twitter.Api object.
 
         Args:
@@ -218,8 +218,8 @@ class Api(object):
           proxies (dict, optional):
             A dictionary of proxies for the request to pass through, if not specified
             allows requests lib to use environmental variables for proxy if any.
-		  verify_ssl (optional):
-		    Either a boolean, in which case it controls whether we verify
+          verify_ssl (optional):
+            Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use. Defaults to ``True``.
           cert_ssl (optional):
@@ -4926,7 +4926,7 @@ class Api(object):
                 timeout=self._timeout,
                 proxies=self.proxies,
                 verify=self.verify_ssl,
-				cert=self.cert_ssl
+                cert=self.cert_ssl
             )
         except requests.RequestException as e:
             raise TwitterError(str(e))


### PR DESCRIPTION
At present, the twitter.Api does not contain verify and cert parameters which exist in requests.request. These parameters help in dealing with SSL certificate verification. In our project, we needed to bypass this verification but by default requests.request was verifying the SSL certificates and creating an issue for us. We simply included the said parameters in the twitter.Api as verify_ssl and verify_cert and used it subsequently in the call to requests.request

If some further changes are to be made, let us know - we could modify accordingly too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/556)
<!-- Reviewable:end -->
