### PR TITLE
fix typo in dict passed to TwitterError

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -2,7 +2,7 @@
 
 #
 #
-# Copyright 2007-2016 The Python-Twitter Developers
+# Copyright 2007-2016, 2018 The Python-Twitter Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -4882,7 +4882,7 @@ class Api(object):
                 raise TwitterError({'message': "Exceeded connection limit for user"})
             if "Error 401 Unauthorized" in json_data:
                 raise TwitterError({'message': "Unauthorized"})
-            raise TwitterError({'Unknown error: {0}'.format(json_data)})
+            raise TwitterError({'Unknown error': '{0}'.format(json_data)})
         self._CheckForTwitterError(data)
         return data
 


### PR DESCRIPTION
fixes a minor issue in construction of dict passed to TwitterError

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/560)
<!-- Reviewable:end -->
