### PR TITLE
migrate api.PostDirectMessage to new twitter api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ htmlcov
 nosetests.xml
 htmlcov
 coverage.xml
+.hypothesis
 
 # PyCharm data
 .idea

--- a/testdata/post_post_direct_message.json
+++ b/testdata/post_post_direct_message.json
@@ -1,1 +1,22 @@
-{"id":761517675243679747,"id_str":"761517675243679747","text":"test message","sender":{"id":4012966701,"id_str":"4012966701","name":"notinourselves","screen_name":"notinourselves","location":"","description":"","url":null,"entities":{"description":{"urls":[]}},"protected":true,"followers_count":1,"friends_count":2,"listed_count":1,"created_at":"Wed Oct 21 23:53:04 +0000 2015","favourites_count":1,"utc_offset":null,"time_zone":null,"geo_enabled":true,"verified":false,"statuses_count":83,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"000000","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/736320724164448256\/LgaAQoav.jpg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/736320724164448256\/LgaAQoav.jpg","profile_background_tile":false,"profile_image_url":"http:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_2_normal.png","profile_image_url_https":"https:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_2_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/4012966701\/1453123196","profile_link_color":"000000","profile_sidebar_border_color":"000000","profile_sidebar_fill_color":"000000","profile_text_color":"000000","profile_use_background_image":true,"has_extended_profile":false,"default_profile":false,"default_profile_image":true,"following":false,"follow_request_sent":false,"notifications":false},"sender_id":4012966701,"sender_id_str":"4012966701","sender_screen_name":"notinourselves","recipient":{"id":372018022,"id_str":"372018022","name":"jeremy","screen_name":"__jcbl__","location":"not a very good kingdom tbh","description":"my kingdom for a microwave that doesn't beep","url":"http:\/\/t.co\/wtg3XzqQTX","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/wtg3XzqQTX","expanded_url":"http:\/\/iseverythingstilltheworst.com","display_url":"iseverythingstilltheworst.com","indices":[0,22]}]},"description":{"urls":[]}},"protected":false,"followers_count":79,"friends_count":423,"listed_count":8,"created_at":"Sun Sep 11 23:49:28 +0000 2011","favourites_count":2696,"utc_offset":-14400,"time_zone":"Eastern Time (US & Canada)","geo_enabled":false,"verified":false,"statuses_count":587,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFFFFF","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/755782670572027904\/L5YRsZAY_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/755782670572027904\/L5YRsZAY_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/372018022\/1469027675","profile_link_color":"EE3355","profile_sidebar_border_color":"000000","profile_sidebar_fill_color":"000000","profile_text_color":"000000","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":true,"follow_request_sent":false,"notifications":false},"recipient_id":372018022,"recipient_id_str":"372018022","recipient_screen_name":"__jcbl__","created_at":"Fri Aug 05 11:02:16 +0000 2016","entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[]}}
+{
+  "event": {
+    "created_timestamp": "1534347829024",
+    "message_create": {
+      "message_data": {
+        "text": "test message",
+        "entities": {
+          "symbols": [],
+          "user_mentions": [],
+          "hashtags": [],
+          "urls": []
+        }
+      },
+      "sender_id": "4012966701",
+      "target": {
+        "recipient_id": "372018022"
+      }
+    },
+    "type": "message_create",
+    "id": "761517675243679747"
+  }
+}

--- a/tests/test_api_30.py
+++ b/tests/test_api_30.py
@@ -1643,15 +1643,9 @@ class ApiTest(unittest.TestCase):
             status=200)
         resp = self.api.PostDirectMessage(text="test message", user_id=372018022)
         self.assertEqual(resp.text, "test message")
-
-        resp = self.api.PostDirectMessage(text="test message", screen_name="__jcbl__")
-        self.assertEqual(resp.sender_id, 4012966701)
-        self.assertEqual(resp.recipient_id, 372018022)
+        self.assertEqual(resp.sender_id, "4012966701")
+        self.assertEqual(resp.recipient_id, "372018022")
         self.assertTrue(resp._json)
-
-        self.assertRaises(
-            twitter.TwitterError,
-            lambda: self.api.PostDirectMessage(text="test message"))
 
     @responses.activate
     def testDestroyDirectMessage(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,28 +58,6 @@ class ModelsTest(unittest.TestCase):
         self.assertTrue(dm.AsJsonString())
         self.assertTrue(dm.AsDict())
 
-    def test_direct_message_sender_is_user_model(self):
-        """Test that each Direct Message object contains a fully hydrated
-        twitter.models.User object for both ``dm.sender`` & ``dm.recipient``."""
-        dm = twitter.DirectMessage.NewFromJsonDict(self.DIRECT_MESSAGE_SAMPLE_JSON)
-
-        self.assertTrue(isinstance(dm.sender, twitter.models.User))
-        self.assertEqual(dm.sender.id, 372018022)
-
-        # Let's make sure this doesn't break the construction of the DM object.
-        self.assertEqual(dm.id, 678629245946433539)
-
-    def test_direct_message_recipient_is_user_model(self):
-        """Test that each Direct Message object contains a fully hydrated
-        twitter.models.User object for both ``dm.sender`` & ``dm.recipient``."""
-        dm = twitter.DirectMessage.NewFromJsonDict(self.DIRECT_MESSAGE_SAMPLE_JSON)
-
-        self.assertTrue(isinstance(dm.recipient, twitter.models.User))
-        self.assertEqual(dm.recipient.id, 4012966701)
-
-        # Same as above.
-        self.assertEqual(dm.id, 678629245946433539)
-
     def test_hashtag(self):
         """ Test twitter.Hashtag object """
         ht = twitter.Hashtag.NewFromJsonDict(self.HASHTAG_SAMPLE_JSON)

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -185,21 +185,13 @@ class DirectMessage(TwitterModel):
         self.param_defaults = {
             'created_at': None,
             'id': None,
-            'recipient': None,
             'recipient_id': None,
-            'recipient_screen_name': None,
-            'sender': None,
             'sender_id': None,
-            'sender_screen_name': None,
             'text': None,
         }
 
         for (param, default) in self.param_defaults.items():
             setattr(self, param, kwargs.get(param, default))
-        if 'sender' in kwargs:
-            self.sender = User.NewFromJsonDict(kwargs.get('sender', None))
-        if 'recipient' in kwargs:
-            self.recipient = User.NewFromJsonDict(kwargs.get('recipient', None))
 
     def __repr__(self):
         if self.text and len(self.text) > 140:
@@ -208,7 +200,7 @@ class DirectMessage(TwitterModel):
             text = self.text
         return "DirectMessage(ID={dm_id}, Sender={sender}, Created={time}, Text='{text!r}')".format(
             dm_id=self.id,
-            sender=self.sender_screen_name,
+            sender=self.sender_id,
             time=self.created_at,
             text=text)
 


### PR DESCRIPTION
This PR migrates the existing PostDirectMessage method to use the new Twitter API documented at https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event.

This is a breaking change as both the input format and the response format are quite different; for example `screen_name` is no longer supported as a parameter, and the return result also no longer contains hydrated `recipient` and `sender` objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/579)
<!-- Reviewable:end -->
