### PR TITLE
Fixed 'additional_owner' does not work properly

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1278,7 +1278,7 @@ class Api(object):
         if additional_owners and len(additional_owners) > 100:
             raise TwitterError({'message': 'Maximum of 100 additional owners may be specified for a Media object'})
         if additional_owners:
-            parameters['additional_owners'] = additional_owners
+            parameters['additional_owners'] = ','.join(map(str,additional_owners))
         if media_category:
             parameters['media_category'] = media_category
 


### PR DESCRIPTION
'TwitterApi' requires a comma-separated string, but passed an array.

https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload-init

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/599)
<!-- Reviewable:end -->
