### PR TITLE
Fix typing issue in `Api._ParseAndCheckTwitter`

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -4965,7 +4965,7 @@ class Api(object):
                 raise TwitterError({'message': "Exceeded connection limit for user"})
             if "Error 401 Unauthorized" in json_data:
                 raise TwitterError({'message': "Unauthorized"})
-            raise TwitterError({'Unknown error': '{0}'.format(json_data)})
+            raise TwitterError({'message': 'Unknown error': '{0}'.format(json_data)})
         self._CheckForTwitterError(data)
         return data
 


### PR DESCRIPTION
Right now whenever the twitter API returns an un-parsable response that isn't explicitly known/handled, the TwitterException sets the message parameter to a `set` type, not a `dict` type or a `str` type (which is used in some cases elsewhere). 

This is causing errors for me as I'm inspecting this exception for graceful error handling, and received a `set` much to my surprise! Looks to me like a copy/paste bug. 

I'd like to have it be a `dict`, but if you think a `str` is more appropriate that works too! 

Thanks for the great library :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/606)
<!-- Reviewable:end -->
