### PR TITLE
Fix typing issue and parameter count issue in GetSearch method.

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -451,7 +451,7 @@ class Api(object):
               >>> # or:
               >>> api.GetSearch(geocode=("37.781157", "-122.398720", "1mi"))
           count (int, optional):
-            Number of results to return.  Default is 15 and maxmimum that
+            Number of results to return.  Default is 15 and maximum that
             Twitter returns is 100 irrespective of what you type in.
           lang (str, optional):
             Language for results as ISO 639-1 code.  Default is None
@@ -523,7 +523,7 @@ class Api(object):
             url = "{url}?{raw_query}".format(
                 url=url,
                 raw_query=raw_query)
-            resp = self._RequestUrl(url, 'GET')
+            resp = self._RequestUrl(url, 'GET', data=parameters)
         else:
             resp = self._RequestUrl(url, 'GET', data=parameters)
 


### PR DESCRIPTION
Hi everyone, Actually when you try to make a Search using GetSearch the system always returns 15 values (using default value of 15) even when you change this values to a different values between 0 and 100 (as specs) the system always display 15. I had to fix this for my project i am working in a private project for an important client and that was the solution.

The second part of the PR is a typo in the documentation in the same method.

Thanks for the your hard and awesome work creating this library :)

I hope it could help us. Have a great day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/607)
<!-- Reviewable:end -->
