### PR TITLE
Remove `future` dependency

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,3 @@
-future
 requests
 requests-oauthlib
 sphinx

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -1,4 +1,3 @@
-future
 requests
 requests-oauthlib
 responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-future
 requests
 requests-oauthlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,6 @@ ignore =
 [flake8]
 ignore = E111,E124,E126,E221,E501
 
-[pep8]
+[pycodestyle]
 ignore = E111,E124,E126,E221,E501
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     download_url=extract_metaitem('download_url'),
     packages=find_packages(exclude=('tests', 'docs')),
     platforms=['Any'],
-    install_requires=['future', 'requests', 'requests-oauthlib'],
+    install_requires=['requests', 'requests-oauthlib'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     keywords='twitter api',

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -7,7 +7,7 @@ class FileCacheTest(unittest.TestCase):
     def testInit(self):
         """Test the twitter._FileCache constructor"""
         cache = twitter._FileCache()
-        self.assert_(cache is not None, 'cache is None')
+        self.assertTrue(cache is not None, 'cache is None')
 
     def testSet(self):
         """Test the twitter._FileCache.Set method"""
@@ -38,6 +38,6 @@ class FileCacheTest(unittest.TestCase):
         cache.Set("foo", 'Hello World!')
         cached_time = cache.GetCachedTime("foo")
         delta = cached_time - now
-        self.assert_(delta <= 1,
-                     'Cached time differs from clock time by more than 1 second.')
+        self.assertTrue(delta <= 1,
+                        'Cached time differs from clock time by more than 1 second.')
         cache.Remove("foo")


### PR DESCRIPTION
As suggested in #571, removed `future` dependency.
I've double checked and found no code that uses any of the backports provided by `future`.
All the code seems to be Python 2/3 compatible using `try ... except ImportError` and such.

Also took the chance to fix a few deprecation warnings I got while running the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/614)
<!-- Reviewable:end -->
