### PR TITLE
Always add tweet_mode to API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ violations.flake8.txt
 
 # Built docs
 doc/_build/**
+
+# Mypy cache
+**/.mypy_cache
+
+# VS Code
+**/.vscode

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -5107,6 +5107,8 @@ class Api(object):
         if not data:
             data = {}
 
+        data['tweet_mode'] = self.tweet_mode
+
         if verb == 'POST':
             if data:
                 if 'media_ids' in data:
@@ -5122,7 +5124,6 @@ class Api(object):
                 resp = 0  # POST request, but without data or json
 
         elif verb == 'GET':
-            data['tweet_mode'] = self.tweet_mode
             url = self._BuildUrl(url, extra_params=data)
             resp = self._session.get(url, auth=self.__auth, timeout=self._timeout, proxies=self.proxies)
 


### PR DESCRIPTION
I discovered I wasn't getting the full_text attribute from the PostUpdate endpoint, only a truncated text. This is because Api._RequestUrl() only added the tweet_mode parameter to GET requests. But the Twitter API docs explicitly say: "add the [tweet_mode=extended] parameters to *any* endpoint" (my emphasis). https://developer.twitter.com/en/docs/tweets/tweet-updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/660)
<!-- Reviewable:end -->
