### PR TITLE
Feature: Allow ability to upload gifs in the range of 5MB to 15MB.

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1277,6 +1277,10 @@ class Api(object):
         parameters['media_type'] = media_type
         parameters['total_bytes'] = file_size
 
+        # Without this GIF files over 5MB but less than 15MB will fail uploading.
+        if media_type == 'image/gif' and file_size > 5242880:
+          parameters['media_category'] = 'tweet_gif'
+
         resp = self._RequestUrl(url, 'POST', data=parameters)
         data = self._ParseAndCheckTwitter(resp.content.decode('utf-8'))
 


### PR DESCRIPTION
Fixes https://github.com/bear/python-twitter/issues/662.

This is my first commit to this repository and I do have a couple of questions.

1. Would it be preferred that we add the media category for all gifs?
2. Would it be better to pass the media category for all gifs?

Thank you for the help!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/663)
<!-- Reviewable:end -->
