### PR TITLE
replace mimetypes to filetype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 requests-oauthlib
+filetype

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     download_url=extract_metaitem('download_url'),
     packages=find_packages(exclude=('tests', 'docs')),
     platforms=['Any'],
-    install_requires=['requests', 'requests-oauthlib'],
+    install_requires=['requests', 'requests-oauthlib', 'filetype'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     keywords='twitter api',

--- a/twitter/twitter_utils.py
+++ b/twitter/twitter_utils.py
@@ -2,7 +2,7 @@
 """Collection of utilities for use in API calls, functions."""
 from __future__ import unicode_literals
 
-import mimetypes
+import filetype
 import os
 import re
 import sys
@@ -274,10 +274,7 @@ def parse_media_file(passed_media, async_upload=False):
     except Exception as e:
         pass
 
-    media_type = mimetypes.guess_type(os.path.basename(filename))[0]
-    # The .srt extension is not recognised by the mimetypes module.
-    if os.path.basename(filename).endswith('.srt'):
-        media_type = 'text/srt'
+    media_type = filetype.guess_mime(data_file.name)
     if media_type is not None:
         if media_type in img_formats and file_size > 5 * 1048576:
             raise TwitterError({'message': 'Images must be less than 5MB.'})


### PR DESCRIPTION
mimetypes relies on file extension, while filetype relies on file header which is more stable.
#391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/684)
<!-- Reviewable:end -->
