### PR TITLE
docs: fix simple typo, unsuccesful -> unsuccessful

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -1403,7 +1403,7 @@ class Api(object):
         Returns:
             media_id:
                 ID of the uploaded media returned by the Twitter API. Raises if
-                unsuccesful.
+                unsuccessful.
         """
 
         media_id, media_fp, filename = self._UploadMediaChunkedInit(media=media,


### PR DESCRIPTION
There is a small typo in twitter/api.py.

Should read `unsuccessful` rather than `unsuccesful`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/686)
<!-- Reviewable:end -->
