### PR TITLE
Fix for PyPI's README not being rendered correctly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,9 +111,9 @@ Using
 
 The library provides a Python wrapper around the Twitter API and the Twitter data model. To get started, check out the examples in the examples/ folder or read the documentation at https://python-twitter.readthedocs.io which contains information about getting your authentication keys from Twitter and using the library.
 
-----
+------------------
 Using with Django
-----
+------------------
 
 Additional template tags that expand tweet urls and urlize tweet text. See the django template tags available for use with python-twitter: https://github.com/radzhome/python-twitter-django-tags
 
@@ -195,9 +195,9 @@ or check out the inline documentation with::
 
     $ pydoc twitter.Api
 
-----
+------
 Todo
-----
+------
 
 Patches, pull requests, and bug reports are `welcome <https://github.com/bear/python-twitter/issues/new>`_, just please keep the style consistent with the original source.
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, print_function
 # limitations under the License.
 
 import os
+from pdb import set_trace
 import re
 import codecs
 
@@ -30,6 +31,19 @@ def read(filename):
     with codecs.open(os.path.join(cwd, filename), 'rb', 'utf-8') as h:
         return h.read()
 
+def convert_txt(txt):
+    lst_txt = txt.split('\n')
+    for i in range(len(lst_txt)):
+        line = lst_txt[i]
+        match = re.match(r' +(\S.+)', line)
+        if match is not None:
+            lst_txt[i] = '\n| {}'.format(match.group(1))
+        else:
+            match_date = re.match(r'(\d+-\d+-\d+)', line)
+            if match_date is not None:
+                lst_txt[i] = '\n**{}**'.format(match_date.group(1))
+    return '\n'.join(lst_txt)
+
 metadata = read(os.path.join(cwd, 'twitter', '__init__.py'))
 
 def extract_metaitem(meta):
@@ -41,13 +55,13 @@ def extract_metaitem(meta):
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
 
 setup(
-    name='python-twitter_test',
+    name='python-twitter',
     version=extract_metaitem('version'),
     license=extract_metaitem('license'),
     description=extract_metaitem('description'),
     long_description=(read('README.rst') + '\n\n' +
                       read('AUTHORS.rst') + '\n\n' +
-                      read('CHANGES')),
+                      convert_txt(read('CHANGES'))),
     long_description_content_type = 'text/x-rst',
     author=extract_metaitem('author'),
     author_email=extract_metaitem('email'),

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import, print_function
 # limitations under the License.
 
 import os
-from pdb import set_trace
 import re
 import codecs
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     long_description=(read('README.rst') + '\n\n' +
                       read('AUTHORS.rst') + '\n\n' +
                       read('CHANGES')),
+    long_description_content_type = 'text/x-rst',
     author=extract_metaitem('author'),
     author_email=extract_metaitem('email'),
     maintainer=extract_metaitem('author'),

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def extract_metaitem(meta):
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
 
 setup(
-    name='python-twitter',
+    name='python-twitter_test',
     version=extract_metaitem('version'),
     license=extract_metaitem('license'),
     description=extract_metaitem('description'),


### PR DESCRIPTION
Dear Developers,

Thank you very much for your help.

I was looking at the [PyPI site of this project](https://pypi.org/project/python-twitter/3.5/).
And I found that the rich text was not compiling the right way, resulting in a broken layout.

So I tried to find out the cause of the problem. The reasons are the following two points.
1. "---" which indicates paragraph titles, is too short.
2. the "CHANGES" file contains indentations.

Adding some "-" solves problem 1.
The function which I added in setup.py solves problem 2.

I have confirmed on the [PyPI test server](https://test.pypi.org/project/python-twitter-test0/) that these fixes make the compilation work.

Another possible solution is to remove the "CHANGES" file from the PyPI long_descrition.
However, I decided that it would be better to include the file and took the above solution.

I hope you will consider it.

Sincerely,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/python-twitter/696)
<!-- Reviewable:end -->
